### PR TITLE
Remove support for tls

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,18 @@
+std = 'max'
+include_files = {
+    'net.lua',
+    'lib/*.lua',
+    'lib/*/*.lua',
+    'test/*_test.lua',
+}
+ignore = {
+    -- unused argument
+    '212',
+    --    -- unused loop variable
+    --    '213',
+    --    -- redefining a local variable
+    --    '411',
+    --    -- shadowing a local variable
+    --    '421',
+}
+

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ this is wrapper module for llsocket module.
 ## Dependencies
 
 - halo: https://github.com/mah0x211/lua-halo
-- libtls: https://github.com/mah0x211/lua-libtls
 - llsocket: https://github.com/mah0x211/lua-llsocket
 
 
@@ -673,19 +672,6 @@ send iovec messages at once.
 synchronous version of writev method that uses advisory lock.
 
 
-### ok, err, timeout = sock:handshake()
-
-performs the TLS handshake. It is only necessary to call this function if you need to guarantee that the handshake has completed, as both `recv()` and `send()` method family will call this method if necessary.
-
-**NOTE:** if the socket is not using TLS, this method always returns true.
-
-**Returns**
-
-- `ok:boolean`: true on success.
-- `err:string`: error message.
-- `timeout:boolean`: true if operation has timed out.
-
-
 ***
 
 
@@ -868,14 +854,13 @@ accept a connection.
 - `err:string`: error string.
 
 
-### sock = sock:createConnection( sock, tls )
+### sock = sock:createConnection( sock )
 
 create a connection socket as a [net.stream.Socket](#netstreamsocket).
 
 **Parameters**
 
 - `sock:`: instance of [llsocket.socket](https://github.com/mah0x211/lua-llsocket#llsocketsocket-instance-methods)
-- `tls:libtls.config`: instance of [libtls](https://github.com/mah0x211/lua-libtls#client-err--ctxaccept_socket-fd-)
 
 **Returns**
 
@@ -902,7 +887,6 @@ create an instance of [net.stream.inet.Server](#netstreaminetserver).
     - `reuseaddr:boolean`: enable the SO_REUSEADDR flag. (default `true`)
     - `reuseport:boolean`: enable the SO_REUSEPORT flag.
     - `tcpnodelay:boolean`: enable the TCP_NODELAY flag. (default `false` in blocking mode)
-    - `tlscfg:libtls.config`: instance of [libtls.config](https://github.com/mah0x211/lua-libtls#libtlsconfig-module)
 
 **Returns**
 
@@ -938,8 +922,6 @@ create an instance of [net.stream.inet.Client](#netstreaminetclient) and initiat
     - `host:string`: hostname.
     - `port:string`: either a decimal port number or a service name listed in services(5).
     - `tcpnodelay:boolean`: enable the TCP_NODELAY flag. (default `false` in blocking mode)
-    - `tlscfg:libtls.config`: instance of [libtls.config](https://github.com/mah0x211/lua-libtls#libtlsconfig-module)
-    - `servername:string`: servername.
 - `connect:boolean`: to connect immediately. (default `true`)
 - `conndeadl:number`: specify a timeout milliseconds as unsigned integer.
 
@@ -989,8 +971,7 @@ create an instance of [net.stream.unix.Server](#netstreamunixserver).
 
 - `opts:table`: following fields are defined;
     - `pathname:string`: pathname of unix domain socket.
-    - `tlscfg:libtls.config`: instance of [libtls.config](https://github.com/mah0x211/lua-libtls#libtlsconfig-module)
-
+    
 **Returns**
 
 - `sock:net.stream.unix.Server`: instance of net.stream.unix.Server.
@@ -1030,8 +1011,6 @@ create an instance of [net.stream.unix.Client](#netstreamunixclient) and initiat
 
 - `opts:table`: following fields are defined;
     - `pathname:string`: pathname of unix domain socket.
-    - `tlscfg:libtls.config`: instance of [libtls.config](https://github.com/mah0x211/lua-libtls#libtlsconfig-module)
-    - `servername:string`: servername.
 - `connect:boolean`: to connect immediately. (default `true`)
 - `conndeadl:number`: specify a timeout milliseconds as unsigned integer.
 

--- a/lib/dgram/inet.lua
+++ b/lib/dgram/inet.lua
@@ -42,20 +42,21 @@ local Socket = {}
 function Socket:connect(opts)
     if not opts then
         return self.sock:connect()
-    else
-        local addrs, err = getaddrinfo(opts)
+    end
 
-        if not err then
-            for _, addr in ipairs(addrs) do
-                err = self.sock:connect(addr)
-                if not err then
-                    break
-                end
-            end
-        end
-
+    local addrs, err = getaddrinfo(opts)
+    if err then
         return err
     end
+
+    for _, addr in ipairs(addrs) do
+        err = self.sock:connect(addr)
+        if not err then
+            break
+        end
+    end
+
+    return err
 end
 
 --- bind
@@ -69,20 +70,21 @@ end
 function Socket:bind(opts)
     if not opts then
         return self.sock:bind()
-    else
-        local addrs, err = getaddrinfo(opts)
+    end
 
-        if not err then
-            for _, addr in ipairs(addrs) do
-                err = self.sock:bind(addr)
-                if not err then
-                    break
-                end
-            end
-        end
-
+    local addrs, err = getaddrinfo(opts)
+    if err then
         return err
     end
+
+    for _, addr in ipairs(addrs) do
+        err = self.sock:bind(addr)
+        if not err then
+            break
+        end
+    end
+
+    return err
 end
 
 Socket = require('metamodule').new.Socket(Socket, 'net.dgram.Socket')
@@ -99,32 +101,33 @@ Socket = require('metamodule').new.Socket(Socket, 'net.dgram.Socket')
 local function new(opts)
     local addrs, err = getaddrinfo(opts)
 
-    if not err then
-        local sock
+    if err then
+        return nil, err
+    end
 
-        for _, addr in ipairs(addrs) do
-            sock, err = socket.new(addr)
-            if not err then
-                -- enable reuseaddr
-                if opts.reuseaddr == true then
-                    _, err = sock:reuseaddr(true)
-                    if err then
-                        sock:close()
-                        return nil, err
-                    end
+    local sock
+    for _, addr in ipairs(addrs) do
+        sock, err = socket.new(addr)
+        if not err then
+            -- enable reuseaddr
+            if opts.reuseaddr == true then
+                _, err = sock:reuseaddr(true)
+                if err then
+                    sock:close()
+                    return nil, err
                 end
-
-                -- enable reuseport
-                if opts.reuseport == true then
-                    _, err = sock:reuseport(true)
-                    if err then
-                        sock:close()
-                        return nil, err
-                    end
-                end
-
-                return Socket(sock)
             end
+
+            -- enable reuseport
+            if opts.reuseport == true then
+                _, err = sock:reuseport(true)
+                if err then
+                    sock:close()
+                    return nil, err
+                end
+            end
+
+            return Socket(sock)
         end
     end
 

--- a/lib/dgram/unix.lua
+++ b/lib/dgram/unix.lua
@@ -41,15 +41,14 @@ local Socket = {}
 function Socket:connect(opts)
     if not opts then
         return self.sock:connect()
-    else
-        local addr, err = getaddrinfo(opts)
-
-        if not err then
-            err = self.sock:connect(addr)
-        end
-
-        return err
     end
+
+    local addr, err = getaddrinfo(opts)
+    if not err then
+        err = self.sock:connect(addr)
+    end
+
+    return err
 end
 
 --- bind
@@ -59,15 +58,14 @@ end
 function Socket:bind(opts)
     if not opts then
         return self.sock:bind()
-    else
-        local addr, err = getaddrinfo(opts)
-
-        if not err then
-            err = self.sock:bind(addr)
-        end
-
-        return err
     end
+
+    local addr, err = getaddrinfo(opts)
+    if not err then
+        err = self.sock:bind(addr)
+    end
+
+    return err
 end
 
 Socket = require('metamodule').new.Socket(Socket, 'net.dgram.Socket',
@@ -80,12 +78,12 @@ Socket = require('metamodule').new.Socket(Socket, 'net.dgram.Socket',
 -- @return err
 local function new(opts)
     local addr, err = getaddrinfo(opts)
-    local sock
 
     if err then
         return nil, err
     end
 
+    local sock
     sock, err = socket.new(addr)
     if err then
         return nil, err

--- a/lib/poll.lua
+++ b/lib/poll.lua
@@ -37,7 +37,7 @@ end
 -- @return ok
 -- @return err
 -- @return timeout
-local function waitReadable()
+local function waitReadable(fd, msec)
     return true
 end
 
@@ -47,25 +47,25 @@ end
 -- @return ok
 -- @return err
 -- @return timeout
-local function waitWritable()
+local function waitWritable(fd, msec)
     return true
 end
 
 --- unwaitReadable
 -- @param fd
-local function unwaitReadable()
+local function unwaitReadable(fd)
     return true
 end
 
 --- unwaitWritable
 -- @param fd
-local function unwaitWritable()
+local function unwaitWritable(fd)
     return true
 end
 
 --- unwait
 -- @param fd
-local function unwait()
+local function unwait(fd)
     return true
 end
 
@@ -75,13 +75,13 @@ end
 -- @return ok
 -- @return err
 -- @return timeout
-local function readLock()
+local function readLock(fd, msec)
     return true
 end
 
 --- readUnlock
 -- @param fd
-local function readUnlock()
+local function readUnlock(fd)
 end
 
 --- writeLock
@@ -90,13 +90,13 @@ end
 -- @return ok
 -- @return err
 -- @return timeout
-local function writeLock()
+local function writeLock(fd, msec)
     return true
 end
 
 --- writeUnlock
 -- @param fd
-local function writeUnlock()
+local function writeUnlock(fd)
 end
 
 --- load event poller module

--- a/rockspecs/net-scm-1.rockspec
+++ b/rockspecs/net-scm-1.rockspec
@@ -12,7 +12,6 @@ description = {
 dependencies = {
     "lua >= 5.1",
     "metamodule >= 0.2.0",
-    "libtls >= 2.7.3-2",
     "llsocket >= 0.11.0",
     "iovec >= 0.1.0",
 }


### PR DESCRIPTION
TLS communication is strongly dependent on the library, it is difficult to solve the problem when the library has a problem. therefore, it should be separated into dedicated modules.