### PR TITLE
Update build configuration

### DIFF
--- a/rockspecs/net-scm-1.rockspec
+++ b/rockspecs/net-scm-1.rockspec
@@ -1,3 +1,4 @@
+rockspec_format = "3.0"
 package = "net"
 version = "scm-1"
 source = {
@@ -25,13 +26,22 @@ dependencies = {
     "time-clock >= 0.4",
 }
 external_dependencies = {
-    OPENSSL = {
-        header = "openssl/ssl.h",
-        library = "ssl",
-    },
+    -- external_dependencies field must be defined to preventing luarocks
+    -- autodetecting dependencies and causing build failure when the
+    -- dependencies are not found.
+}
+build_dependencies = {
+    "luarocks-build-hooks >= 0.6.0",
 }
 build = {
-    type = "builtin",
+    type = "hooks",
+    before_build = "$(pkgconfig)",
+    pkgconfig_dependencies = {
+        ["OPENSSL"] = {
+            header = "openssl/ssl.h",
+            library = "ssl",
+        },
+    },
     modules = {
         net = "net.lua",
         ["net.addrinfo"] = "lib/addrinfo.lua",
@@ -55,40 +65,37 @@ build = {
         ["net.tls.context"] = {
             sources = "src/tls_context.c",
             incdirs = {
-                "$(OPENSSL_DIR)/include",
+                "$(OPENSSL_INCDIR)",
             },
             libdirs = {
-                "$(OPENSSL_DIR)/lib",
+                "$(OPENSSL_LIBDIR)",
             },
             libraries = {
-                "ssl",
-                "crypto",
+                "$(OPENSSL_LIB)",
             },
         },
         ["net.tls.client"] = {
             sources = "src/tls_client.c",
             incdirs = {
-                "$(OPENSSL_DIR)/include",
+                "$(OPENSSL_INCDIR)",
             },
             libdirs = {
-                "$(OPENSSL_DIR)/lib",
+                "$(OPENSSL_LIBDIR)",
             },
             libraries = {
-                "ssl",
-                "crypto",
+                "$(OPENSSL_LIB)",
             },
         },
         ["net.tls.server"] = {
             sources = "src/tls_server.c",
             incdirs = {
-                "$(OPENSSL_DIR)/include",
+                "$(OPENSSL_INCDIR)",
             },
             libdirs = {
-                "$(OPENSSL_DIR)/lib",
+                "$(OPENSSL_LIBDIR)",
             },
             libraries = {
-                "ssl",
-                "crypto",
+                "$(OPENSSL_LIB)",
             },
         },
     },


### PR DESCRIPTION
This pull request updates the `rockspecs/net-scm-1.rockspec` file to improve how external dependencies—particularly OpenSSL—are handled during the build process. The changes make the build configuration more robust and compatible with modern LuaRocks practices, reducing the risk of build failures due to missing dependencies.

Dependency and build configuration improvements:

* Switched the `rockspec_format` to "3.0" for better compatibility with newer LuaRocks features.
* Replaced the old `external_dependencies` and `builtin` build type with a `build_dependencies` field and a `build` section that uses the `hooks` type, explicitly listing `luarocks-build-hooks` as a build dependency.
* Updated OpenSSL configuration to use `pkgconfig`-style variables (`OPENSSL_INCDIR`, `OPENSSL_LIBDIR`, `OPENSSL_LIB`) instead of hardcoded directory paths and library names, making the build process more portable and flexible.