### PR TITLE
Refactor deadline handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
         luacheck .
 
   test:
+    needs: luacheck
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/mah0x211/lua-ci:latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
-.DS_Store
+_*
+.*
 *.so
 *.o
+*.out
+*.gcno
+*.gcda
+*.gcov
+*.key
+*.crt
+*.pem
+*.p12

--- a/lib/dgram.lua
+++ b/lib/dgram.lua
@@ -124,18 +124,18 @@ end
 --- @return addrinfo? ai
 function Socket:recvfrom(...)
     local sock, recvfrom = self.sock, self.sock.recvfrom
-    local deadline, sec = self:get_recv_deadline()
+    local deadline = self:get_recv_deadline()
 
     while true do
         local str, err, again, ai = recvfrom(sock, ...)
 
         if not again then
             return str, err, again, ai
-        elseif deadline then
-            sec = deadline:remain()
-            if sec <= 0 then
-                return nil, nil, true
-            end
+        end
+
+        local done, sec = deadline:is_done()
+        if done then
+            return nil, nil, true
         end
 
         -- wait until readable
@@ -165,7 +165,7 @@ end
 --- @return boolean? timeout
 function Socket:sendto(str, ai, ...)
     local sock, sendto = self.sock, self.sock.sendto
-    local deadline, sec = self:get_send_deadline()
+    local deadline = self:get_send_deadline()
     local sent = 0
 
     while true do
@@ -179,11 +179,11 @@ function Socket:sendto(str, ai, ...)
 
         if not again then
             return sent
-        elseif deadline then
-            sec = deadline:remain()
-            if sec <= 0 then
-                return sent, nil, true
-            end
+        end
+
+        local done, sec = deadline:is_done()
+        if done then
+            return sent, nil, true
         end
 
         -- wait until writable

--- a/lib/stream.lua
+++ b/lib/stream.lua
@@ -98,7 +98,7 @@ end
 --- @return boolean? timeout
 function Socket:sendfile(fd, bytes, offset)
     local sock, sendfile = self.sock, self.sock.sendfile
-    local deadline, sec = self:get_send_deadline()
+    local deadline = self:get_send_deadline()
     local sent = 0
 
     if not offset then
@@ -116,11 +116,11 @@ function Socket:sendfile(fd, bytes, offset)
 
         if not again then
             return sent, err
-        elseif deadline then
-            sec = deadline:remain()
-            if sec <= 0 then
-                return sent, nil, true
-            end
+        end
+
+        local done, sec = deadline:is_done()
+        if done then
+            return sent, nil, true
         end
 
         -- wait until writable

--- a/lib/tls.lua
+++ b/lib/tls.lua
@@ -71,18 +71,18 @@ end
 --- @return boolean? timeout
 function Socket:tls_close()
     local tls, close = self.tls, self.tls.close
-    local deadline, sec = self:get_send_deadline()
+    local deadline = self:get_send_deadline()
 
     while true do
         local ok, err, want = close(tls)
 
         if not want then
             return ok, err
-        elseif deadline then
-            sec = deadline:remain()
-            if sec <= 0 then
-                return false, new_errno('ETIMEDOUT'), true
-            end
+        end
+
+        local done, sec = deadline:is_done()
+        if done then
+            return false, nil, true
         end
 
         local timeout
@@ -119,7 +119,7 @@ function Socket:handshake()
     end
 
     local tls, handshake = self.tls, self.tls.handshake
-    local deadline, sec = self:get_send_deadline()
+    local deadline = self:get_send_deadline()
 
     while true do
         local ok, err, want = handshake(tls)
@@ -127,11 +127,11 @@ function Socket:handshake()
         if not want then
             self.handshaked = ok
             return ok, err
-        elseif deadline then
-            sec = deadline:remain()
-            if sec <= 0 then
-                return false, new_errno('ETIMEDOUT'), true
-            end
+        end
+
+        local done, sec = deadline:is_done()
+        if done then
+            return false, nil, true
         end
 
         local timeout
@@ -150,6 +150,9 @@ end
 --- @return any err
 --- @return boolean? timeout
 function Socket:read(bufsize)
+    local deadline = self:get_recv_deadline()
+
+    -- perform handshake if not yet
     if not self.handshaked then
         local ok, err, timeout = self:handshake()
         if not ok then
@@ -158,8 +161,6 @@ function Socket:read(bufsize)
     end
 
     local sock, read = self.tls, self.tls.read
-    local deadline, sec = self:get_recv_deadline()
-
     -- NOTE: in the edge trigger mode on macOS with kqueue,
     -- If the read function returns WANT_POLLIN several times, the event will
     -- no longer occur.
@@ -168,16 +169,16 @@ function Socket:read(bufsize)
     local nread = 0
 
     while true do
+        local done, sec = deadline:is_done()
+        if done then
+            return nil, nil, true
+        end
+
         nread = nread + 1
         local str, err, want = read(sock, bufsize)
 
         if not want then
             return str, err
-        elseif deadline then
-            sec = deadline:remain()
-            if sec <= 0 then
-                return nil, new_errno('ETIMEDOUT'), true
-            end
         end
 
         if nread > 5 then
@@ -224,6 +225,9 @@ end
 --- @return any err
 --- @return boolean? timeout
 function Socket:write(str)
+    local deadline = self:get_send_deadline()
+
+    -- perform handshake if not yet
     if not self.handshaked then
         local ok, err, timeout = self:handshake()
         if not ok then
@@ -232,12 +236,15 @@ function Socket:write(str)
     end
 
     local sock, write = self.tls, self.tls.write
-    local deadline, sec = self:get_send_deadline()
     local sent = 0
 
     while true do
-        local len, err, want = write(sock, str)
+        local done, sec = deadline:is_done()
+        if done then
+            return sent, nil, true
+        end
 
+        local len, err, want = write(sock, str)
         if not len then
             return nil, err
         end
@@ -246,11 +253,6 @@ function Socket:write(str)
 
         if not want then
             return sent
-        elseif deadline then
-            sec = deadline:remain()
-            if sec <= 0 then
-                return sent, new_errno('ETIMEDOUT'), true
-            end
         end
 
         local ok, perr, timeout = self:poll_wait(want, sec)

--- a/lib/unix.lua
+++ b/lib/unix.lua
@@ -35,7 +35,7 @@ local Socket = {}
 --- @return boolean? timeout
 function Socket:sendfd(fd, ai, ...)
     local sock, sendfd = self.sock, self.sock.sendfd
-    local deadline, sec = self:get_send_deadline()
+    local deadline = self:get_send_deadline()
 
     while true do
         local len, err, again = sendfd(sock, fd, ai, ...)
@@ -44,11 +44,11 @@ function Socket:sendfd(fd, ai, ...)
             return nil, err
         elseif not again then
             return len
-        elseif deadline then
-            sec = deadline:remain()
-            if sec <= 0 then
-                return len, nil, true
-            end
+        end
+
+        local done, sec = deadline:is_done()
+        if done then
+            return len, nil, true
         end
 
         -- wait until writable
@@ -77,18 +77,18 @@ end
 --- @return boolean? timeout
 function Socket:recvfd(...)
     local sock, recvfd = self.sock, self.sock.recvfd
-    local deadline, sec = self:get_recv_deadline()
+    local deadline = self:get_recv_deadline()
 
     while true do
         local fd, err, again = recvfd(sock, ...)
 
         if not again then
             return fd, err, again
-        elseif deadline then
-            sec = deadline:remain()
-            if sec <= 0 then
-                return nil, nil, true
-            end
+        end
+
+        local done, sec = deadline:is_done()
+        if done then
+            return nil, nil, true
         end
 
         -- wait until readable

--- a/net.lua
+++ b/net.lua
@@ -43,9 +43,13 @@ local llsocket = require('llsocket')
 --- @class time.clock.deadline
 --- @field time fun(time.clock.deadline):number
 --- @field remain fun(time.clock.deadline):number
+--- @field is_done fun(time.clock.deadline):(boolean, number)
 
 --- @type fun(duration: number):(time.clock.deadline, number)
 local new_deadline = require('time.clock.deadline').new
+
+-- default max timeout for 60 minutes, which is the maximum timeout of poll_wait_* functions
+local DEFAULT_MAX_TIMEOUT = 60 * 60
 
 --- constants
 local SHUT_RD = llsocket.SHUT_RD
@@ -342,11 +346,9 @@ end
 --- @return time.clock.deadline? deadline
 --- @return number? sec
 function Socket:get_recv_deadline()
-    local sec = self.rcvdeadl
-    if sec ~= nil then
-        assert(is_finite(sec), 'rcvtimeo must be finite-number')
-        return new_deadline(sec), sec
-    end
+    local sec = self.rcvdeadl or DEFAULT_MAX_TIMEOUT
+    assert(is_finite(sec), 'rcvtimeo must be finite-number')
+    return new_deadline(sec), sec
 end
 
 --- sndtimeo
@@ -368,11 +370,9 @@ end
 --- @return time.clock.deadline? deadline
 --- @return number? sec
 function Socket:get_send_deadline()
-    local sec = self.snddeadl
-    if sec ~= nil then
-        assert(is_finite(sec), 'sendtimeo must be finite-number')
-        return new_deadline(sec), sec
-    end
+    local sec = self.snddeadl or DEFAULT_MAX_TIMEOUT
+    assert(is_finite(sec), 'sendtimeo must be finite-number')
+    return new_deadline(sec), sec
 end
 
 --- linger
@@ -411,18 +411,18 @@ end
 --- @return boolean? timeout
 function Socket:read(bufsize)
     local sock, read = self.sock, self.sock.read
-    local deadline, sec = self:get_recv_deadline()
+    local deadline = self:get_recv_deadline()
 
     while true do
         local str, err, again = read(sock, bufsize)
 
         if not again then
             return str, err, again
-        elseif deadline then
-            sec = deadline:remain()
-            if sec <= 0 then
-                return nil, nil, true
-            end
+        end
+
+        local done, sec = deadline:is_done()
+        if done then
+            return nil, nil, true
         end
 
         -- wait until readable
@@ -450,18 +450,18 @@ end
 --- @return boolean? timeout
 function Socket:recv(bufsize, ...)
     local sock, recv = self.sock, self.sock.recv
-    local deadline, sec = self:get_recv_deadline()
+    local deadline = self:get_recv_deadline()
 
     while true do
         local str, err, again = recv(sock, bufsize, ...)
 
         if not again then
             return str, err, again
-        elseif deadline then
-            sec = deadline:remain()
-            if sec <= 0 then
-                return nil, nil, true
-            end
+        end
+
+        local done, sec = deadline:is_done()
+        if done then
+            return nil, nil, true
         end
 
         -- wait until readable
@@ -490,18 +490,18 @@ end
 --- @return boolean? timeout
 function Socket:recvmsg(mh, ...)
     local sock, recvmsg = self.sock, self.sock.recvmsg
-    local deadline, sec = self:get_recv_deadline()
+    local deadline = self:get_recv_deadline()
 
     while true do
         local len, err, again = recvmsg(sock, mh.msg, ...)
 
         if not again then
             return len, err, again
-        elseif deadline then
-            sec = deadline:remain()
-            if sec <= 0 then
-                return nil, nil, true
-            end
+        end
+
+        local done, sec = deadline:is_done()
+        if done then
+            return nil, nil, true
         end
 
         -- wait until readable
@@ -531,7 +531,7 @@ end
 --- @return boolean? timeout
 function Socket:readv(iov, offset, nbyte)
     local sock, readv = self.sock, iov.readv
-    local deadline, sec = self:get_recv_deadline()
+    local deadline = self:get_recv_deadline()
 
     if offset == nil then
         offset = 0
@@ -542,11 +542,11 @@ function Socket:readv(iov, offset, nbyte)
 
         if not again then
             return len, err, again
-        elseif deadline then
-            sec = deadline:remain()
-            if sec <= 0 then
-                return nil, nil, true
-            end
+        end
+
+        local done, sec = deadline:is_done()
+        if done then
+            return nil, nil, true
         end
 
         -- wait until readable
@@ -595,7 +595,7 @@ end
 --- @return boolean? timeout
 function Socket:write(str)
     local sock, write = self.sock, self.sock.write
-    local deadline, sec = self:get_send_deadline()
+    local deadline = self:get_send_deadline()
     local sent = 0
 
     while true do
@@ -609,11 +609,11 @@ function Socket:write(str)
 
         if not again then
             return sent
-        elseif deadline then
-            sec = deadline:remain()
-            if sec <= 0 then
-                return sent, nil, true
-            end
+        end
+
+        local done, sec = deadline:is_done()
+        if done then
+            return sent, nil, true
         end
 
         -- wait until writable
@@ -643,7 +643,7 @@ end
 --- @return boolean? timeout
 function Socket:send(str, ...)
     local sock, send = self.sock, self.sock.send
-    local deadline, sec = self:get_send_deadline()
+    local deadline = self:get_send_deadline()
     local sent = 0
 
     while true do
@@ -657,11 +657,11 @@ function Socket:send(str, ...)
 
         if not again then
             return sent
-        elseif deadline then
-            sec = deadline:remain()
-            if sec <= 0 then
-                return sent, nil, true
-            end
+        end
+
+        local done, sec = deadline:is_done()
+        if done then
+            return sent, nil, true
         end
 
         -- wait until writable
@@ -697,7 +697,7 @@ function Socket:sendmsg(mh, ...)
     end
 
     local sock, sendmsg = self.sock, self.sock.sendmsg
-    local deadline, sec = self:get_send_deadline()
+    local deadline = self:get_send_deadline()
     local sent = 0
 
     while true do
@@ -713,11 +713,11 @@ function Socket:sendmsg(mh, ...)
 
         if not again then
             return sent
-        elseif deadline then
-            sec = deadline:remain()
-            if sec <= 0 then
-                return sent, nil, true
-            end
+        end
+
+        local done, sec = deadline:is_done()
+        if done then
+            return sent, nil, true
         end
 
         -- wait until writable
@@ -747,7 +747,7 @@ end
 --- @return boolean? timeout
 function Socket:writev(iov, offset, nbyte)
     local sock, writev = self.sock, iov.writev
-    local deadline, sec = self:get_send_deadline()
+    local deadline = self:get_send_deadline()
     local sent = 0
 
     if offset == nil then
@@ -767,11 +767,11 @@ function Socket:writev(iov, offset, nbyte)
 
         if not again then
             return sent, err
-        elseif deadline then
-            sec = deadline:remain()
-            if sec <= 0 then
-                return sent, nil, true
-            end
+        end
+
+        local done, sec = deadline:is_done()
+        if done then
+            return sent, nil, true
         end
 
         -- wait until writable

--- a/rockspecs/net-scm-1.rockspec
+++ b/rockspecs/net-scm-1.rockspec
@@ -23,7 +23,7 @@ dependencies = {
     "io-fopen >= 0.1.3",
     "io-pread >= 0.1.0",
     "iovec >= 0.3",
-    "time-clock >= 0.4",
+    "time-clock >= 0.5.0",
 }
 external_dependencies = {
     -- external_dependencies field must be defined to preventing luarocks
@@ -35,11 +35,23 @@ build_dependencies = {
 }
 build = {
     type = "hooks",
-    before_build = "$(pkgconfig)",
+    before_build = {
+        "$(pkgconfig)",
+        "$(extra-vars)",
+    },
     pkgconfig_dependencies = {
         ["OPENSSL"] = {
             header = "openssl/ssl.h",
             library = "ssl",
+        },
+    },
+    extra_variables = {
+        CFLAGS = "-Wall -Wno-trigraphs -Wmissing-field-initializers -Wreturn-type -Wmissing-braces -Wparentheses -Wno-switch -Wunused-function -Wunused-label -Wunused-parameter -Wunused-variable -Wunused-value -Wuninitialized -Wunknown-pragmas -Wshadow -Wsign-compare",
+    },
+    conditional_variables = {
+        NET_COVERAGE = {
+            CFLAGS = "--coverage",
+            LIBFLAG = "--coverage",
         },
     },
     modules = {
@@ -63,7 +75,9 @@ build = {
         ["net.tls.stream.inet"] = "lib/tls/stream/inet.lua",
         ["net.tls.stream.unix"] = "lib/tls/stream/unix.lua",
         ["net.tls.context"] = {
-            sources = "src/tls_context.c",
+            sources = {
+                "src/tls_context.c",
+            },
             incdirs = {
                 "$(OPENSSL_INCDIR)",
             },


### PR DESCRIPTION
This pull request refactors how socket operation timeouts are handled throughout the codebase. The main change is the consistent use of a new `is_done()` method on deadline objects, replacing manual timeout checks. Additionally, a default maximum timeout is introduced for socket operations to ensure consistent behavior when no explicit timeout is set.

The most important changes include:

**Timeout Handling Refactor:**

* All socket read/write methods now use the `is_done()` method on deadline objects to check for timeouts, replacing the previous pattern of manually checking the remaining time. This results in cleaner and more reliable timeout handling across `net.lua`, `dgram.lua`, `stream.lua`, `tls.lua`, and `unix.lua`. [[1]](diffhunk://#diff-5dd716a81d9f871f2bc3bf5fe42f1afb4ecc674d830637d193fca5708017700dL414-R425) [[2]](diffhunk://#diff-6bfce6105f5df28d13b1b18a6901d3a69a9e348a6fce9f1bfc3fa8bacbb0f818L127-R138) [[3]](diffhunk://#diff-9b2b0bfbfed909b193dd269f979181873a2bf294639388bdac840b8c97da066eL101-R101) [[4]](diffhunk://#diff-e0e185b05f3416aa184a3d4fd79ae4a4444ec10f615d54e05a205383d0b3022bL74-R85) [[5]](diffhunk://#diff-aaf23348a465594b217b2b3c9c704966d24bdc27aa23f48c17ec2381e412f081L38-R38)

* The deadline object interface is updated to require an `is_done()` method, and all socket methods are updated to use this new interface.

**Default Timeout Behavior:**

* Introduced a `DEFAULT_MAX_TIMEOUT` constant (60 minutes) that is used as the default deadline for socket operations if no explicit timeout is set, ensuring operations do not hang indefinitely. This affects both receive and send deadlines. [[1]](diffhunk://#diff-5dd716a81d9f871f2bc3bf5fe42f1afb4ecc674d830637d193fca5708017700dL345-L350) [[2]](diffhunk://#diff-5dd716a81d9f871f2bc3bf5fe42f1afb4ecc674d830637d193fca5708017700dL371-L376)

**Workflow Improvement:**

* The GitHub Actions workflow is updated so that the `test` job depends on the `luacheck` job, ensuring code is linted before tests run.