### PR TITLE
Refactor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,10 @@
 name: test
 
 on:
-    push:
-      branches:
-        - '**'
-      paths-ignore:
-        - '**.md'
-        - 'LICENSE'
+  push:
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
 
 jobs:
   luacheck:
@@ -27,6 +25,8 @@ jobs:
 
   test:
     needs: luacheck
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/mah0x211/lua-ci:latest
@@ -52,15 +52,16 @@ jobs:
     -
       name: Install
       run: |
-        luarocks make
+        NET_COVERAGE=1 luarocks make
     -
       name: Install Tools
       run: |
         luarocks install testcase
         luarocks install luacov
-        luarocks install exec
+        luarocks install assert
+        LAUXH_INCDIR=$(luarocks show lauxhlib --rock-dir)/conf
+        luarocks install exec CFLAGS="-O2 -fPIC -include lauxhlib.h -I${LAUXH_INCDIR}"
         luarocks install io-fileno
-        luarocks install io-tofile
         luarocks install io-wait
     -
       name: Run Test
@@ -68,18 +69,9 @@ jobs:
         testcase --coverage ./test/
     -
       name: Upload lua coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        use_oidc: true
+        disable_search: true
         files: ./luacov.report.out
         flags: unittests
-    # -
-    #   name: Generate coverage reports
-    #   run: |
-    #     sh ./covgen.sh
-    # -
-    #   name: Upload c coverage to Codecov
-    #   uses: codecov/codecov-action@v2
-    #   with:
-    #     files: ./coverage/lcov.info
-    #     flags: unittests

--- a/rockspecs/net-scm-1.rockspec
+++ b/rockspecs/net-scm-1.rockspec
@@ -31,7 +31,7 @@ external_dependencies = {
     -- dependencies are not found.
 }
 build_dependencies = {
-    "luarocks-build-hooks >= 0.6.0",
+    "luarocks-build-hooks >= 0.8.0",
 }
 build = {
     type = "hooks",
@@ -79,6 +79,8 @@ build = {
                 "src/tls_context.c",
             },
             incdirs = {
+                "$(DEP_ERROR_INCDIR)",
+                "$(DEP_LAUXHLIB_INCDIR)",
                 "$(OPENSSL_INCDIR)",
             },
             libdirs = {
@@ -91,6 +93,8 @@ build = {
         ["net.tls.client"] = {
             sources = "src/tls_client.c",
             incdirs = {
+                "$(DEP_ERROR_INCDIR)",
+                "$(DEP_LAUXHLIB_INCDIR)",
                 "$(OPENSSL_INCDIR)",
             },
             libdirs = {
@@ -103,6 +107,8 @@ build = {
         ["net.tls.server"] = {
             sources = "src/tls_server.c",
             incdirs = {
+                "$(DEP_ERROR_INCDIR)",
+                "$(DEP_LAUXHLIB_INCDIR)",
                 "$(OPENSSL_INCDIR)",
             },
             libdirs = {

--- a/src/tls.h
+++ b/src/tls.h
@@ -24,19 +24,15 @@
 #ifndef net_tls_h
 #define net_tls_h
 
-#include <arpa/inet.h>
-#include <openssl/err.h>
-#include <openssl/ocsp.h>
-#include <openssl/ssl.h>
-#include <openssl/x509_vfy.h>
-#include <openssl/x509v3.h>
-#include <stdio.h>
-#include <string.h>
-#include <sys/socket.h>
-#include <unistd.h>
+// depend
+#include "lauxhlib.h"
+#include "lua_error.h"
 // lua
-#include <lauxhlib.h>
-#include <lua_error.h>
+#include <lua.h>
+// system
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#include <stddef.h>
 
 typedef struct {
     lua_State *L;

--- a/src/tls_client.c
+++ b/src/tls_client.c
@@ -21,7 +21,24 @@
  *
  */
 
+// project
 #include "tls.h"
+// depend
+#include "lauxhlib.h"
+// lua
+#include <lauxlib.h>
+// system
+#include <openssl/asn1.h>
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/ocsp.h>
+#include <openssl/pem.h>
+#include <openssl/ssl.h>
+#include <openssl/x509.h>
+#include <openssl/x509_vfy.h>
+#include <openssl/x509v3.h>
+#include <stdio.h>
 
 // set callback for ALPN (Application-Layer Protocol Negotiation) support
 // SSL_CTX_set_alpn_select_cb(ctx->sslctx, alpn_select_cb, ctx);

--- a/src/tls_context.c
+++ b/src/tls_context.c
@@ -20,7 +20,20 @@
  *  DEALINGS IN THE SOFTWARE.
  *
  */
+// project
 #include "tls.h"
+// depend
+#include "lauxhlib.h"
+// lua
+#include <lauxlib.h>
+// system
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#include <openssl/x509_vfy.h>
+#include <stdio.h>
+#include <sys/types.h>
 
 static int handshake_lua(lua_State *L)
 {

--- a/src/tls_server.c
+++ b/src/tls_server.c
@@ -21,7 +21,17 @@
  *
  */
 
+// project
 #include "tls.h"
+// depend
+#include "lauxhlib.h"
+// lua
+#include <lauxlib.h>
+// system
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <openssl/ssl.h>
+#include <stdio.h>
 
 static int sni_callback(SSL *ssl, int *al, void *arg)
 {


### PR DESCRIPTION
This pull request updates the build configuration and source includes to improve dependency management, compatibility, and security for the project. The most significant changes are grouped below by theme.

**Build and Dependency Management:**

* Updated the required version of `luarocks-build-hooks` to `>= 0.8.0` in `rockspecs/net-scm-1.rockspec` for improved build support.
* Added `$(DEP_ERROR_INCDIR)` and `$(DEP_LAUXHLIB_INCDIR)` to the `incdirs` for `net.tls.context`, `net.tls.client`, and `net.tls.server` modules to ensure proper inclusion of dependency headers. [[1]](diffhunk://#diff-bc8a079deef767743a9e68f45ebd2caa109d80797509fb290493b6c0357e8cb5R82-R83) [[2]](diffhunk://#diff-bc8a079deef767743a9e68f45ebd2caa109d80797509fb290493b6c0357e8cb5R96-R97) [[3]](diffhunk://#diff-bc8a079deef767743a9e68f45ebd2caa109d80797509fb290493b6c0357e8cb5R110-R111)

**GitHub Actions Workflow Enhancements:**

* Updated the test workflow to use OIDC authentication for Codecov uploads, set `id-token: write` permissions, and improved tool installation steps for better security and reliability. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R28-R29) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L55-L85)
* Changed the Codecov action version from v4 to v5 and removed the need for a secret token by using OIDC.
* Updated the test installation step to enable network coverage and improved the installation of dependencies, including using `assert` and setting compilation flags for `exec`.

**Source Code Include Cleanup:**

* Refactored `#include` directives in `src/tls.h`, `src/tls_client.c`, `src/tls_context.c`, and `src/tls_server.c` to clearly separate project, dependency, Lua, and system includes, and to ensure all necessary headers are included in the correct order. [[1]](diffhunk://#diff-0f6c14e769c60a5db66811ae95af5812ef4e60b0e322a990878564102a77e707L27-R35) [[2]](diffhunk://#diff-910a4c21211f43f58b72e5d6b78803203bc9f05edf868b31d2497aef9a28accdR24-R41) [[3]](diffhunk://#diff-536836db70b2c8f8fbe38b8c578da84a6b0409d9f179eed344c08e7f7e961839R23-R36) [[4]](diffhunk://#diff-f296796deff8179cb1c1e1d4a007f8fdb543eb66f648049990840c9e2f1689b0R24-R34)