### PR TITLE
Add memory BIO support and integeration

### DIFF
--- a/doc/net_tls.md
+++ b/doc/net_tls.md
@@ -1,9 +1,25 @@
-# Constants of net.tls.context
+# Constants and helpers of net.tls.context
 
-[net.tls.context](../src/tls_context.c) module exports the following constants.
+[net.tls.context](../src/tls_context.c) module exports the following constants
+and helper.
 
 ## Required file descriptor states
 
 - `WANT_READ`: The underlying read file descriptor needs to be readable in order to continue.
 - `WANT_WRITE`: The underlying write file descriptor needs to be writeable in order to continue.
 
+## encrypted_length = context.encrypted_length( protocol )
+
+Returns the maximum on-the-wire TLS record length for the given protocol
+policy.
+
+- `protocol`: one of `default`, `tlsv1`, `tlsv1.0`, `tlsv1.1`, `tlsv1.2`,
+  `tlsv1.3`.
+- The returned value is used as the minimum safe BIO buffer size when the
+  memory-BIO transport is enabled.
+
+## Memory BIO buffer size
+
+When `context.accept()` / `context.connect()` are called with `use_bio=true`,
+an optional trailing `bufcap` can be supplied. If omitted, or smaller than
+`context.encrypted_length(protocol)`, the minimum safe size is used.

--- a/lib/stream/inet.lua
+++ b/lib/stream/inet.lua
@@ -101,7 +101,8 @@ local function new_client(host, port, opts)
             ctx, err = tls_connect(tls, sock:fd(), opts.servername,
                                    opts.tlscfg.noverify_name,
                                    opts.tlscfg.noverify_time,
-                                   opts.tlscfg.noverify_cert)
+                                   opts.tlscfg.noverify_cert,
+                                   opts.tlscfg.use_bio)
             if not ctx then
                 sock:close()
                 return nil, err
@@ -150,7 +151,8 @@ local function new_server(host, port, opts)
         socket_bind(host, port, opts.reuseaddr, opts.reuseport)
     if sock then
         if tls then
-            return tls_stream_inet.Server(sock, tls), nil, ai
+            return tls_stream_inet.Server(sock, tls, opts.tlscfg.use_bio), nil,
+                   ai
         end
         return Server(sock), nil, ai
     end

--- a/lib/stream/unix.lua
+++ b/lib/stream/unix.lua
@@ -95,7 +95,8 @@ local function new_client(pathname, opts)
             ctx, err = tls_connect(tls, sock:fd(), opts.servername,
                                    opts.tlscfg.noverify_name,
                                    opts.tlscfg.noverify_time,
-                                   opts.tlscfg.noverify_cert)
+                                   opts.tlscfg.noverify_cert,
+                                   opts.tlscfg.use_bio)
             if not ctx then
                 sock:close()
                 return nil, err
@@ -135,7 +136,7 @@ local function new_server(pathname, tlscfg)
     local sock, err, ai = socket_bind(pathname)
     if sock then
         if tls then
-            return tls_stream_unix.Server(sock, tls), nil, ai
+            return tls_stream_unix.Server(sock, tls, tlscfg.use_bio), nil, ai
         end
         return Server(sock), nil, ai
     end

--- a/lib/tls.lua
+++ b/lib/tls.lua
@@ -23,12 +23,87 @@
 local format = string.format
 local tostring = tostring
 local new_errno = require('errno').new
+local new_deadline = require('time.clock.deadline').new
 --- constants
 local WANT_POLLIN = require('net.tls.context').WANT_READ
 local WANT_POLLOUT = require('net.tls.context').WANT_WRITE
 
 --- @class net.tls.Socket : net.Socket
 local Socket = {}
+
+--- bio_fill
+--- @private
+--- @param sec number?
+--- @return boolean ok
+--- @return any err
+--- @return boolean? timeout
+function Socket:bio_fill(sec)
+    local bio = self.tls_bio
+    if not bio then
+        return true
+    end
+
+    local deadline = sec and new_deadline(sec)
+    while true do
+        if deadline then
+            sec = deadline:remain()
+            if sec <= 0 then
+                return false, nil, true
+            end
+        end
+
+        local n, err, again = bio:fill()
+        if n then
+            return true
+        elseif not again then
+            return false, err
+        end
+
+        local ok, timeout
+        ok, err, timeout = self:wait_readable(sec)
+        if not ok then
+            return false, err, timeout
+        end
+        -- do read again
+    end
+end
+
+--- bio_drain
+--- @private
+--- @param sec number?
+--- @return boolean ok
+--- @return any err
+--- @return boolean? timeout
+function Socket:bio_drain(sec)
+    local bio = self.tls_bio
+    if not bio then
+        return true
+    end
+
+    local deadline = sec and new_deadline(sec)
+    while true do
+        if deadline then
+            sec = deadline:remain()
+            if sec <= 0 then
+                return false, nil, true
+            end
+        end
+
+        local n, err, again = bio:drain()
+        if n then
+            return true
+        elseif not again then
+            return false, err
+        end
+
+        local ok, timeout
+        ok, err, timeout = self:wait_writable(sec)
+        if not ok then
+            return false, err, timeout
+        end
+        -- do write again
+    end
+end
 
 --- poll_wait
 --- @param want integer
@@ -39,8 +114,22 @@ local Socket = {}
 function Socket:poll_wait(want, sec)
     -- wait by poll function
     if want == WANT_POLLIN then
+        -- if use BIO, drain any pending encrypted record(s) to fd first (the
+        -- peer may be waiting for our outgoing data, e.g. handshake flights),
+        -- then fill the buffer with newly received ciphertext(s) from fd.
+        if self.tls_bio then
+            local ok, err, timeout = self:bio_drain(sec)
+            if not ok then
+                return false, err, timeout
+            end
+            return self:bio_fill(sec)
+        end
         return self:wait_readable(sec)
     elseif want == WANT_POLLOUT then
+        -- if use BIO, drain the newly encrypted record(s) to fd
+        if self.tls_bio then
+            return self:bio_drain(sec)
+        end
         return self:wait_writable(sec)
     end
     return false,
@@ -75,9 +164,25 @@ function Socket:tls_close()
 
     while true do
         local ok, err, want = close(tls)
+        local timeout
 
         if not want then
-            return ok, err
+            if not ok then
+                -- close failed
+                return false, err
+            end
+
+            -- close succeeded
+            -- if use BIO, drain the newly encrypted record(s) to fd
+            local done, sec = deadline:is_done()
+            if done then
+                return false, nil, true
+            end
+            ok, err, timeout = self:bio_drain(sec)
+            if not ok then
+                return false, err, timeout
+            end
+            return true
         end
 
         local done, sec = deadline:is_done()
@@ -85,7 +190,6 @@ function Socket:tls_close()
             return false, nil, true
         end
 
-        local timeout
         ok, err, timeout = self:poll_wait(want, sec)
         if not ok then
             return false, err, timeout
@@ -123,10 +227,22 @@ function Socket:handshake()
 
     while true do
         local ok, err, want = handshake(tls)
+        local timeout
 
         if not want then
-            self.handshaked = ok
-            return ok, err
+            if not ok then
+                -- handshake failed
+                return false, err
+            end
+
+            -- handshake succeeded
+            -- if use BIO, drain the newly encrypted record(s) to fd
+            local done, sec = deadline:is_done()
+            if done then
+                return false, nil, true
+            end
+            self.handshaked, err, timeout = self:bio_drain(sec)
+            return self.handshaked, err, timeout
         end
 
         local done, sec = deadline:is_done()
@@ -134,7 +250,6 @@ function Socket:handshake()
             return false, nil, true
         end
 
-        local timeout
         ok, err, timeout = self:poll_wait(want, sec)
         if not ok then
             -- error or timeout occurred
@@ -176,16 +291,28 @@ function Socket:read(bufsize)
 
         nread = nread + 1
         local str, err, want = read(sock, bufsize)
+        local ok, timeout
 
         if not want then
-            return str, err
+            if not str then
+                -- read failed
+                return nil, err
+            end
+
+            -- read succeeded
+            -- if use BIO, drain the newly encrypted record(s) to fd
+            ok, err, timeout = self:bio_drain(sec)
+            if not ok then
+                return nil, err, timeout
+            end
+            return str
         end
 
         if nread > 5 then
             nread = 0
-            local ok, perr, timeout = self:poll_wait(want, sec)
+            ok, err, timeout = self:poll_wait(want, sec)
             if not ok then
-                return nil, perr, timeout
+                return nil, err, timeout
             end
         end
         -- do read again
@@ -251,13 +378,20 @@ function Socket:write(str)
         -- update a bytes sent
         sent = sent + len
 
+        local ok, timeout
         if not want then
+            -- write succeeded
+            -- if use BIO, drain the newly encrypted record(s) to fd
+            ok, err, timeout = self:bio_drain(sec)
+            if not ok then
+                return nil, err, timeout
+            end
             return sent
         end
 
-        local ok, perr, timeout = self:poll_wait(want, sec)
+        ok, err, timeout = self:poll_wait(want, sec)
         if not ok then
-            return sent, perr, timeout
+            return sent, err, timeout
         end
 
         str = str:sub(len + 1)

--- a/lib/tls/stream/inet.lua
+++ b/lib/tls/stream/inet.lua
@@ -37,7 +37,7 @@ local Server = {}
 --- @return net.tls.stream.Socket? sock
 --- @return any err
 function Server:new_connection(sock)
-    local tls, err = accept(self.tls, sock:fd())
+    local tls, err = accept(self.tls, sock:fd(), self.use_bio)
 
     if not tls then
         sock:close()

--- a/lib/tls/stream/unix.lua
+++ b/lib/tls/stream/unix.lua
@@ -38,7 +38,7 @@ local Server = {}
 --- @return net.tls.stream.Socket? sock
 --- @return any err
 function Server:new_connection(sock)
-    local tls, err = accept(self.tls, sock:fd())
+    local tls, err = accept(self.tls, sock:fd(), self.use_bio)
 
     if not tls then
         sock:close()

--- a/net.lua
+++ b/net.lua
@@ -59,6 +59,7 @@ local SHUT_RDWR = llsocket.SHUT_RDWR
 --- @class net.Socket
 --- @field sock socket
 --- @field tls? userdata
+--- @field tls_bio? userdata
 local Socket = {}
 
 --[[
@@ -70,10 +71,13 @@ end
 --- init
 --- @param sock socket
 --- @param tls userdata?
+--- @param use_bio boolean?
 --- @return net.Socket self
-function Socket:init(sock, tls)
+function Socket:init(sock, tls, use_bio)
     self.sock = sock
     self.tls = tls
+    self.tls_bio = tls and type(tls.get_bio) == 'function' and tls:get_bio()
+    self.use_bio = use_bio == true
     sock:addgcfn(error, function(fd)
         poll_unwait(fd)
     end, sock:fd())

--- a/rockspecs/net-scm-1.rockspec
+++ b/rockspecs/net-scm-1.rockspec
@@ -77,6 +77,7 @@ build = {
         ["net.tls.context"] = {
             sources = {
                 "src/tls_context.c",
+                "src/tls_bio.c",
             },
             incdirs = {
                 "$(DEP_ERROR_INCDIR)",

--- a/src/tls.h
+++ b/src/tls.h
@@ -34,6 +34,8 @@
 #include <openssl/ssl.h>
 #include <stddef.h>
 
+#include "tls_bio.h"
+
 typedef struct {
     lua_State *L;
     SSL_CTX *ctx;
@@ -54,8 +56,8 @@ typedef int (*tls_handshake_fn)(SSL *);
 
 typedef struct {
     SSL *ssl;
+    tls_bio_t *bio;
     tls_handshake_fn handshake_cb;
-    // parent context reference (tls_server_t or tls_client_t)
     int parent_ref;
 } tls_ctx_t;
 
@@ -134,7 +136,7 @@ typedef enum {
     NET_TLS_PROTO_TLSv1_3,
 } tls_protocol_t;
 
-const char *const TLS_PROTOCOLS[] = {
+static const char *const TLS_PROTOCOLS[] = {
     "default", // TLSv1.2 and TLSv1.3
     "tlsv1",   // TLSv1.0, TLSv1.1, TLSv1.2 and TLSv1.3
     "tlsv1.0", // TLSv1.0
@@ -144,44 +146,95 @@ const char *const TLS_PROTOCOLS[] = {
     NULL,
 };
 
-static int tls_set_protocol_vers(SSL_CTX *ctx, tls_protocol_t protocol)
+static inline void tls_get_protocol_vers(tls_protocol_t protocol, int *minv,
+                                         int *maxv)
 {
-    int minv = 0;
-    int maxv = 0;
+    int min_version = 0;
+    int max_version = 0;
 
     switch (protocol) {
     default:
     case NET_TLS_PROTO_DEFAULT:
-        minv = TLS1_2_VERSION;
+        min_version = TLS1_2_VERSION;
         break;
 
     case NET_TLS_PROTO_TLSv1:
-        minv = TLS1_VERSION;
+        min_version = TLS1_VERSION;
         break;
 
     case NET_TLS_PROTO_TLSv1_0:
-        minv = TLS1_VERSION;
-        maxv = TLS1_VERSION;
+        min_version = TLS1_VERSION;
+        max_version = TLS1_VERSION;
         break;
 
     case NET_TLS_PROTO_TLSv1_1:
-        minv = TLS1_1_VERSION;
-        maxv = TLS1_1_VERSION;
+        min_version = TLS1_1_VERSION;
+        max_version = TLS1_1_VERSION;
         break;
 
     case NET_TLS_PROTO_TLSv1_2:
-        minv = TLS1_2_VERSION;
-        maxv = TLS1_2_VERSION;
+        min_version = TLS1_2_VERSION;
+        max_version = TLS1_2_VERSION;
         break;
 
     case NET_TLS_PROTO_TLSv1_3:
-        minv = TLS1_3_VERSION;
-        maxv = TLS1_3_VERSION;
+        min_version = TLS1_3_VERSION;
+        max_version = TLS1_3_VERSION;
         break;
     }
 
+    if (minv) {
+        *minv = min_version;
+    }
+    if (maxv) {
+        *maxv = max_version;
+    }
+}
+
+static inline int tls_set_protocol_vers(SSL_CTX *ctx, tls_protocol_t protocol)
+{
+    int minv = 0;
+    int maxv = 0;
+
+    tls_get_protocol_vers(protocol, &minv, &maxv);
+
     return SSL_CTX_set_min_proto_version(ctx, minv) == 1 &&
            (maxv <= 0 || SSL_CTX_set_max_proto_version(ctx, maxv) == 1);
+}
+
+#define TLS_RECORD_HEADER_LENGTH  5
+#define TLS_MAX_PLAIN_LENGTH      (16 * 1024)
+#define TLS_COMPRESSED_OVERHEAD   1024
+#define TLS_MAX_PADDING_LENGTH    256
+#define TLS_LEGACY_MAX_MAC_LENGTH 20
+#define TLS12_MAX_MAC_LENGTH      64
+#define TLS_EXPLICIT_IV_LENGTH    16
+#define TLS13_MAX_OVERHEAD        256
+
+static inline size_t tls_get_encrypted_length(int version)
+{
+    switch (version) {
+    case TLS1_VERSION:
+        return TLS_RECORD_HEADER_LENGTH + TLS_MAX_PLAIN_LENGTH +
+               TLS_COMPRESSED_OVERHEAD + TLS_LEGACY_MAX_MAC_LENGTH +
+               TLS_MAX_PADDING_LENGTH;
+
+    case TLS1_1_VERSION:
+        return TLS_RECORD_HEADER_LENGTH + TLS_MAX_PLAIN_LENGTH +
+               TLS_COMPRESSED_OVERHEAD + TLS_EXPLICIT_IV_LENGTH +
+               TLS_LEGACY_MAX_MAC_LENGTH + TLS_MAX_PADDING_LENGTH;
+
+    case TLS1_3_VERSION:
+        /* overhead = AEAD tag (16) + inner type (1) + padding (up to 239) */
+        return TLS_RECORD_HEADER_LENGTH + TLS_MAX_PLAIN_LENGTH +
+               TLS13_MAX_OVERHEAD;
+
+    case TLS1_2_VERSION:
+    default:
+        return TLS_RECORD_HEADER_LENGTH + TLS_MAX_PLAIN_LENGTH +
+               TLS_COMPRESSED_OVERHEAD + TLS_EXPLICIT_IV_LENGTH +
+               TLS12_MAX_MAC_LENGTH + TLS_MAX_PADDING_LENGTH;
+    }
 }
 
 static inline void tls_push_error(lua_State *L, const char *default_errop,

--- a/src/tls_bio.c
+++ b/src/tls_bio.c
@@ -1,0 +1,541 @@
+/*
+ *  Copyright (C) 2026 Masatoshi Fukunaga
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to
+ *  deal in the Software without restriction, including without limitation the
+ *  rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ */
+#include "tls_bio.h"
+#include <errno.h>
+#include <pthread.h>
+
+#include "lua_errno.h"
+
+/**
+ * @brief Called by OpenSSL when a BIO is created.  We use this to initialize
+ * the BIO's data pointer to NULL, and set the init flag to 1.  The BIO will be
+ * associated with a tls_bio_buf_t later when we set up the BIOs for a
+ * tls_ctx_t.
+ *
+ * @param bio The BIO being created.  The BIO's data pointer will be initialized
+ * to NULL, and the init flag will be set to 1.
+ * @return int Always returns 1 to indicate success.  OpenSSL ignores the return
+ * value of this callback, so it doesn't matter what we return.
+ */
+static int bio_create(BIO *bio)
+{
+    BIO_set_init(bio, 1);
+    return 1;
+}
+
+/**
+ * @brief Called by OpenSSL when a BIO is freed.  We clear the data pointer and
+ * reset the init flag.  The associated tls_bio_buf_t is a Lua userdata managed
+ * by Lua's GC and must not be freed here.
+ *
+ * @param bio The BIO being freed.
+ * @return int Always returns 1 to indicate success.
+ */
+static int bio_destroy(BIO *bio)
+{
+    BIO_set_data(bio, NULL);
+    BIO_set_init(bio, 0);
+    return 1;
+}
+
+/**
+ * @brief Called by OpenSSL to perform various control operations on the BIO.
+ * We only need to support the flush operation, which is a no-op for our BIOs
+ * since we don't have any internal buffering.
+ *
+ * @param bio The BIO on which to perform the control operation.
+ * @param cmd The control command to perform.
+ * @param larg A long argument for the control command.
+ * @param parg A pointer argument for the control command.
+ * @return long The result of the control operation.  For unsupported commands,
+ * we return 0.  For the flush command, we return 1.
+ */
+static long bio_ctrl(BIO *bio, int cmd, long larg, void *parg)
+{
+    (void)bio;
+    (void)larg;
+    (void)parg;
+    return (cmd == BIO_CTRL_FLUSH) ? 1 : 0;
+}
+
+/**
+ * @brief Called by OpenSSL to read ciphertext from the receive buffer (rxbuf).
+ * OpenSSL reads raw network bytes (ciphertext) from this BIO to decrypt them
+ * internally.  The rxbuf must have been pre-filled by tls_bio_fill() before
+ * SSL_read() is called.
+ *
+ * @param bio The BIO being read.  The BIO's data pointer is the tls_bio_buf_t
+ * (rxbuf) holding the ciphertext received from the network.
+ * @param buf The buffer into which OpenSSL copies the ciphertext.
+ * @param len The maximum number of bytes to copy into buf.
+ * @return int The number of bytes copied, or -1 with the retry-read flag set
+ * if rxbuf is empty.
+ */
+static int bio_rx_read(BIO *bio, char *buf, int len)
+{
+    tls_bio_buf_t *b = NULL;
+    size_t avail     = 0;
+    void *data       = NULL;
+    int n            = 0;
+
+    // Clear retry flags at the start of each call.  If we need to retry, we'll
+    // set the appropriate flag before returning.
+    BIO_clear_retry_flags(bio);
+    if (len <= 0) {
+        return 0;
+    }
+
+    // OpenSSL calls this function to get ciphertext from the network.
+    // Copy data from rxbuf (filled by tls_bio_fill) into OpenSSL's buffer.
+    b     = BIO_get_data(bio);
+    avail = 0;
+    data  = zring_data(&b->buf, &avail);
+    if (!data) {
+        BIO_set_retry_read(bio);
+        return -1;
+    }
+
+    // Copy at most len bytes from rxbuf into OpenSSL's buffer, and consume them
+    // from rxbuf.  If there are more than len bytes available, we'll return len
+    // and leave the rest for the next call.
+    n = ((size_t)len < avail) ? len : (int)avail;
+    memcpy(buf, data, (size_t)n);
+    zring_consume(&b->buf, (size_t)n);
+    return n;
+}
+
+/**
+ * @brief Called by OpenSSL when it has ciphertext ready to be sent to the
+ * network. The ciphertext data is copied from OpenSSL's write buffer into
+ * txbuf, where it will be picked up by tls_bio_drain and written to the
+ * network.
+ *
+ * @param bio The BIO from which OpenSSL is trying to write ciphertext data. The
+ * BIO's data pointer is a tls_bio_buf_t that contains the txbuf ring buffer
+ * where the ciphertext data is stored.
+ * @param buf The buffer containing the ciphertext data to be written.
+ * @param len The number of bytes to write from buf into txbuf.
+ * @return int The number of bytes written into txbuf, or -1 if a retry is
+ * needed. If txbuf is full and cannot accept any more data, we return -1 and
+ * set the retry write flag, so OpenSSL will know to call us again when txbuf
+ * has space.
+ */
+static int bio_tx_write(BIO *bio, const char *buf, int len)
+{
+    tls_bio_buf_t *b = NULL;
+    void *dst        = NULL;
+    size_t space     = 0;
+    int n            = 0;
+
+    // Clear retry flags at the start of each call.  If we need to retry, we'll
+    // set the appropriate flag before returning.
+    BIO_clear_retry_flags(bio);
+    if (len <= 0) {
+        return 0;
+    }
+
+    // OpenSSL calls this function when it has ciphertext ready to send.
+    // Copy it into txbuf; tls_bio_drain() will write it to the network.
+    b   = BIO_get_data(bio);
+    dst = zring_space(&b->buf, &space);
+    if (!dst) {
+        BIO_set_retry_write(bio);
+        return -1;
+    }
+
+    // Copy at most len bytes from OpenSSL's write buffer into txbuf, and commit
+    // them to txbuf.  If there is more than len bytes of space available, we'll
+    // return len and leave the rest for the next call.  If there is no space
+    // available, we'll return -1 and set the retry write flag, so OpenSSL will
+    // call us again when txbuf has space.
+    n = ((size_t)len < space) ? len : (int)space;
+    memcpy(dst, buf, (size_t)n);
+    zring_commit(&b->buf, (size_t)n);
+    return n;
+}
+
+/**
+ * @brief Called by OpenSSL to write a null-terminated string as ciphertext.
+ * Delegates to bio_tx_write().
+ *
+ * @param bio The BIO being written.
+ * @param str The null-terminated string to write.
+ * @return int The number of bytes written, or -1 with the retry-write flag set
+ * if txbuf is full.
+ */
+static int bio_tx_puts(BIO *bio, const char *str)
+{
+    return bio_tx_write(bio, str, (int)strlen(str));
+}
+
+/**
+ * buf:consume(n: integer)
+ *
+ * Advance the read position by @p n bytes after draining the region
+ * returned by buf:peek().  Raises an error if @p n is negative or exceeds
+ * the contiguous segment reported by buf:peek().
+ *
+ * @param n  Number of bytes consumed from the peek region (>= 0).
+ */
+static int consume_lua(lua_State *L)
+{
+    tls_bio_t *bio = luaL_checkudata(L, 1, NET_TLS_BIO_MT);
+    lua_Integer n  = lauxh_checkinteger(L, 2);
+
+    if (n < 0 || zring_consume(&bio->tx.buf, (size_t)n) != 0) {
+        return luaL_error(L, "consume(%lld): out of range", (long long)n);
+    }
+    return 0;
+}
+
+/**
+ * buf:peek() -> lightuserdata, integer
+ *
+ * Returns a pointer to the next contiguous readable region and its byte
+ * length.  The caller should drain the region (e.g. via POSIX write()) and
+ * then call buf:consume(n) to advance the read position.
+ *
+ * Returns nil, 0 when the buffer is empty.
+ *
+ * @note The returned pointer is only valid until the next call that mutates
+ *       the buffer.  Do not retain it across yield points.
+ */
+static int peek_lua(lua_State *L)
+{
+    tls_bio_t *bio = luaL_checkudata(L, 1, NET_TLS_BIO_MT);
+    size_t len     = 0;
+    void *ptr      = zring_data(&bio->tx.buf, &len);
+
+    if (!ptr) {
+        lua_pushnil(L);
+        lua_pushinteger(L, 0);
+    } else {
+        lua_pushlightuserdata(L, ptr);
+        lua_pushinteger(L, (lua_Integer)len);
+    }
+    return 2;
+}
+
+static int drain_lua(lua_State *L)
+{
+    tls_bio_t *bio = luaL_checkudata(L, 1, NET_TLS_BIO_MT);
+    size_t len     = 0;
+    void *data     = NULL;
+    ssize_t n      = 0;
+    ssize_t total  = 0;
+
+    if (bio->fd < 0) {
+        // bio has already been freed
+        lua_pushnil(L);
+        lua_errno_new(L, EINVAL, "drain");
+        return 2;
+    }
+
+    // Drain as much data as possible from txbuf to the network until txbuf is
+    // empty or we get EAGAIN/EWOULDBLOCK.
+RETRY:
+    data = zring_data(&bio->tx.buf, &len);
+    if (!data) {
+        // fully drained
+        lua_pushinteger(L, total);
+        return 1;
+    }
+
+    n = write(bio->fd, data, len);
+    switch (n) {
+    case -1:
+        if (errno == EINTR) {
+            goto RETRY;
+        } else if (errno == EAGAIN || errno == EWOULDBLOCK) {
+RET_EAGAIN:
+            lua_pushinteger(L, total);
+            lua_pushnil(L);
+            lua_pushboolean(L, 1);
+            return 3;
+        }
+        // got a fatal error
+        lua_pushnil(L);
+        lua_errno_new(L, errno, "drain");
+        return 2;
+
+    case 0:
+        // write(2) returning 0 is not an error, but it means we can't make any
+        // progress draining the buffer.  We'll treat it as EAGAIN to avoid
+        // a busy loop.
+        goto RET_EAGAIN;
+
+    default:
+        // Successfully wrote n bytes; consume them from txbuf and continue.
+        zring_consume(&bio->tx.buf, (size_t)n);
+        total += n;
+        goto RETRY;
+    }
+}
+
+/**
+ * buf:commit(n: integer)
+ *
+ * Advance the write position by @p n bytes after filling the region
+ * returned by buf:space().  Raises an error if @p n is negative or exceeds
+ * the contiguous segment reported by buf:space().
+ *
+ * @param n  Number of bytes written into the space region (>= 0).
+ */
+static int commit_lua(lua_State *L)
+{
+    tls_bio_t *bio = luaL_checkudata(L, 1, NET_TLS_BIO_MT);
+    lua_Integer n  = lauxh_checkinteger(L, 2);
+
+    if (n < 0 || zring_commit(&bio->rx.buf, (size_t)n) != 0) {
+        return luaL_error(L, "commit(%lld): out of range", (long long)n);
+    }
+    return 0;
+}
+
+/**
+ * buf:space() -> lightuserdata, integer
+ *
+ * Returns a pointer to the next contiguous writable region and its byte
+ * length.  The caller should fill the region (e.g. via POSIX read()) and
+ * then call buf:commit(n) to advance the write position.
+ *
+ * Returns nil, 0 when the buffer is full.
+ *
+ * @note The returned pointer is only valid until the next call that mutates
+ *       the buffer.  Do not retain it across yield points.
+ */
+static int space_lua(lua_State *L)
+{
+    tls_bio_t *bio = luaL_checkudata(L, 1, NET_TLS_BIO_MT);
+    size_t len     = 0;
+    void *ptr      = zring_space(&bio->rx.buf, &len);
+
+    if (!ptr) {
+        lua_pushnil(L);
+        lua_pushinteger(L, 0);
+    } else {
+        lua_pushlightuserdata(L, ptr);
+        lua_pushinteger(L, (lua_Integer)len);
+    }
+    return 2;
+}
+
+static int fill_lua(lua_State *L)
+{
+    tls_bio_t *bio = luaL_checkudata(L, 1, NET_TLS_BIO_MT);
+    size_t len     = 0;
+    void *space    = NULL;
+    ssize_t total  = 0;
+    ssize_t n      = 0;
+
+    if (bio->fd < 0) {
+        // bio has already been freed
+        lua_pushnil(L);
+        lua_errno_new(L, EINVAL, "fill");
+        return 2;
+    }
+
+    space = zring_space(&bio->rx.buf, &len);
+    if (!space) {
+        lua_pushnil(L);
+        lua_errno_new(L, ENOBUFS, "fill");
+        return 2;
+    }
+
+RETRY:
+    n = read(bio->fd, space, len);
+    switch (n) {
+    case -1:
+        if (errno == EINTR) {
+            goto RETRY;
+        } else if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            if (!total) {
+                // no data read
+                lua_pushnil(L);
+                lua_pushnil(L);
+                lua_pushboolean(L, 1);
+                return 3;
+            }
+            // partially filled; return the number of bytes filled so far
+            lua_pushinteger(L, total);
+            return 1;
+        }
+        // got a fatal error
+        lua_pushnil(L);
+        lua_errno_new(L, errno, "fill");
+        return 2;
+
+    case 0:
+        // closed by peer; mark EOF by returning 0 without an error
+        return 0;
+
+    default:
+        // Successfully read n bytes; commit them to rxbuf and return n.
+        zring_commit(&bio->rx.buf, (size_t)n);
+        total += n;
+        space = zring_space(&bio->rx.buf, &len);
+        if (!space) {
+            // If there is still space available, we can read more data from the
+            // network
+            goto RETRY;
+        }
+        lua_pushinteger(L, (lua_Integer)total);
+        return 1;
+    }
+}
+
+static int tostring_lua(lua_State *L)
+{
+    tls_bio_t *bio = luaL_checkudata(L, 1, NET_TLS_BIO_MT);
+    lua_pushfstring(L, NET_TLS_BIO_MT ": %p", (void *)bio);
+    return 1;
+}
+
+void tls_bio_free(lua_State *L, tls_bio_t *bio)
+{
+    if (!bio) {
+        return;
+    }
+    if (bio->rx.mem) {
+        BUF_MEM_free(bio->rx.mem);
+        bio->rx.mem = NULL;
+    }
+    if (bio->tx.mem) {
+        BUF_MEM_free(bio->tx.mem);
+        bio->tx.mem = NULL;
+    }
+    bio->fd  = -1;
+    bio->ref = lauxh_unref(L, bio->ref);
+}
+
+static int gc_lua(lua_State *L)
+{
+    tls_bio_t *bio = luaL_checkudata(L, 1, NET_TLS_BIO_MT);
+    tls_bio_free(L, bio);
+    return 0;
+}
+
+static inline int bio_buf_init(tls_bio_buf_t *b, int cap)
+{
+    b->mem = BUF_MEM_new();
+    if (!b->mem) {
+        // failed to allocate BUF_MEM
+        return -1;
+    } else if (BUF_MEM_grow(b->mem, cap) == 0) {
+        // error occurred during buffer allocation
+        BUF_MEM_free(b->mem);
+        return -1;
+    }
+    zring_init(&b->buf, b->mem->data, cap);
+    return 0;
+}
+
+tls_bio_t *tls_bio_new(lua_State *L, int fd, int cap)
+{
+    tls_bio_t *bio = lua_newuserdata(L, sizeof(tls_bio_t));
+
+    bio->fd  = fd;
+    bio->ref = LUA_NOREF;
+    if (bio_buf_init(&bio->rx, cap) != 0 || bio_buf_init(&bio->tx, cap) != 0) {
+        if (bio->rx.mem) {
+            // error occurred during buffer allocation
+            BUF_MEM_free(bio->rx.mem);
+        }
+        return NULL;
+    }
+    lauxh_setmetatable(L, NET_TLS_BIO_MT);
+    bio->ref = lauxh_ref(L);
+    return bio;
+}
+
+static BIO_METHOD *g_rx_bio_method = NULL;
+static BIO_METHOD *g_tx_bio_method = NULL;
+
+int tls_bio_setup(SSL *ssl, tls_bio_t *bio)
+{
+    BIO *rxbio = NULL;
+    BIO *txbio = NULL;
+
+    rxbio = BIO_new(g_rx_bio_method);
+    if (!rxbio) {
+        // hard error, no BIO allocated
+        return -1;
+    }
+    BIO_set_data(rxbio, &bio->rx);
+
+    txbio = BIO_new(g_tx_bio_method);
+    if (!txbio) {
+        BIO_free(rxbio);
+        return -1; /* hard error, no BIO allocated */
+    }
+    BIO_set_data(txbio, &bio->tx);
+
+    /* SSL_set_bio transfers ownership of both BIOs to ssl.
+     * SSL_free() will free them — do not call BIO_free() separately. */
+    SSL_set_bio(ssl, rxbio, txbio);
+    return 0;
+}
+
+static void bio_init_once(void)
+{
+    g_rx_bio_method = BIO_meth_new(BIO_TYPE_SOURCE_SINK | BIO_get_new_index(),
+                                   "net.tls.rxbio");
+    BIO_meth_set_read(g_rx_bio_method, bio_rx_read);
+    BIO_meth_set_ctrl(g_rx_bio_method, bio_ctrl);
+    BIO_meth_set_create(g_rx_bio_method, bio_create);
+    BIO_meth_set_destroy(g_rx_bio_method, bio_destroy);
+
+    g_tx_bio_method = BIO_meth_new(BIO_TYPE_SOURCE_SINK | BIO_get_new_index(),
+                                   "net.tls.txbio");
+    BIO_meth_set_write(g_tx_bio_method, bio_tx_write);
+    BIO_meth_set_puts(g_tx_bio_method, bio_tx_puts);
+    BIO_meth_set_ctrl(g_tx_bio_method, bio_ctrl);
+    BIO_meth_set_create(g_tx_bio_method, bio_create);
+    BIO_meth_set_destroy(g_tx_bio_method, bio_destroy);
+}
+
+/**
+ * @brief Initialises the module-level BIO_METHOD singletons used by all TLS
+ * connections.  Safe to call from multiple threads; the actual
+ * initialisation runs exactly once via pthread_once().
+ */
+void tls_bio_init(lua_State *L)
+{
+    static pthread_once_t g_bio_init_once = PTHREAD_ONCE_INIT;
+    pthread_once(&g_bio_init_once, bio_init_once);
+
+    // rxbuffer
+    luaL_newmetatable(L, NET_TLS_BIO_MT);
+    lauxh_pushfn2tbl(L, "__gc", gc_lua);
+    lauxh_pushfn2tbl(L, "__tostring", tostring_lua);
+    lua_newtable(L);
+
+    lauxh_pushfn2tbl(L, "fill", fill_lua);
+    lauxh_pushfn2tbl(L, "space", space_lua);
+    lauxh_pushfn2tbl(L, "commit", commit_lua);
+
+    lauxh_pushfn2tbl(L, "drain", drain_lua);
+    lauxh_pushfn2tbl(L, "peek", peek_lua);
+    lauxh_pushfn2tbl(L, "consume", consume_lua);
+    lua_setfield(L, -2, "__index");
+    lua_pop(L, 1);
+}

--- a/src/tls_bio.h
+++ b/src/tls_bio.h
@@ -1,0 +1,111 @@
+/**
+ *  Copyright (C) 2026 Masatoshi Fukunaga
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to
+ *  deal in the Software without restriction, including without limitation the
+ *  rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef net_tls_bio_h
+#define net_tls_bio_h
+
+#include <openssl/err.h>
+#include <openssl/ocsp.h>
+#include <openssl/ssl.h>
+#include <openssl/x509_vfy.h>
+#include <openssl/x509v3.h>
+// lua
+#include "lauxhlib.h"
+
+// local
+#include "zring.h"
+
+#define NET_TLS_BIO_MT "net.tls.bio"
+
+/**
+ * @brief Internal ring-buffer object managed as a Lua full userdata.
+ *
+ * One instance is allocated for the receive path (rxbuf) and one for the
+ * transmit path (txbuf) of every TLS context.  The tls_ctx_t owns both via
+ * raw C pointers; @c ref keeps the userdata reachable in the Lua registry so
+ * that the Lua GC does not collect it while the context is still alive.
+ */
+typedef struct {
+    zring_t buf;  /**< Ring buffer operating over @c mem->data. */
+    BUF_MEM *mem; /**< OpenSSL-managed backing memory (NULL after free). */
+} tls_bio_buf_t;
+
+typedef struct {
+    int ref;          /**< prevent premature GC. */
+    int fd;           /**< network socket file descriptor. */
+    tls_bio_buf_t rx; /**< receive ring buffer */
+    tls_bio_buf_t tx; /**< transmit ring buffer */
+} tls_bio_t;
+
+/**
+ * @brief Initialize the module-level BIO method singletons.
+ *
+ * Must be called once (e.g. from luaopen) before any tls_bio_setup() call.
+ *
+ * @param L Lua state, used to register the BIO userdata metatable.
+ */
+void tls_bio_init(lua_State *L);
+
+/**
+ * @brief Wires custom memory BIOs to @p ssl using @p bio's rx and tx buffers.
+ *
+ * @param ssl An SSL object to attach the BIOs to.
+ * @param bio BIO object containing both receive and transmit ring buffers.
+ * @return    0 on success, -1 on failure.
+ */
+int tls_bio_setup(SSL *ssl, tls_bio_t *bio);
+
+/**
+ * @brief Allocate a tls_bio_t full userdata with the given capacity for both
+ * receive and transmit buffers.
+ *
+ * @param L   Lua state, used to allocate the userdata and register the
+ *            metatable.
+ * @param fd  Network socket file descriptor.
+ * @param cap Capacity in bytes for both rx and tx buffers.
+ * @return    Pointer to the allocated tls_bio_t on success, or NULL on failure.
+ */
+tls_bio_t *tls_bio_new(lua_State *L, int fd, int cap);
+
+/**
+ * @brief Free the BIO's associated buffers and release the Lua registry
+ * reference.
+ *
+ * @param L   Lua state, used to free the registry reference.
+ * @param bio BIO to free; may be NULL.
+ */
+void tls_bio_free(lua_State *L, tls_bio_t *bio);
+
+/**
+ * @brief Return the number of bytes of ciphertext data currently stored in the
+ * transmit buffer, i.e. the amount of data waiting to be written to the
+ * network.
+ *
+ * @param bio BIO containing the transmit buffer to query.
+ * @return    Number of bytes of data currently stored in the transmit buffer.
+ */
+static inline size_t tls_bio_tx_size(tls_bio_t *bio)
+{
+    return zring_data_size(&bio->tx.buf);
+}
+
+#endif /* net_tls_bio_h */

--- a/src/tls_context.c
+++ b/src/tls_context.c
@@ -19,15 +19,25 @@
  *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  *  DEALINGS IN THE SOFTWARE.
  *
+ *
+ * Transport path:
+ *   POSIX read(fd)  --> rxbuf --> rxbio --> SSL_read  --> Lua
+ *   Lua             --> SSL_write --> txbio --> txbuf --> POSIX write(fd)
+ *
+ * Both BIOs are backed by ring buffers in tls_bio_buf_t.  The ring buffers hold
+ * the ciphertext that is exchanged with the network fd, keeping OpenSSL from
+ * touching the fd directly.
  */
 // project
 #include "tls.h"
 // depend
 #include "lauxhlib.h"
+#include "lua_errno.h"
 // lua
 #include <lauxlib.h>
 // system
 #include <arpa/inet.h>
+#include <errno.h>
 #include <netinet/in.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>
@@ -35,26 +45,75 @@
 #include <stdio.h>
 #include <sys/types.h>
 
+static int handshake_bio_lua(lua_State *L, tls_ctx_t *ctx)
+{
+    int rv = ctx->handshake_cb(ctx->ssl);
+    if (rv == 1) {
+        // Handshake is only complete once the last handshake flight has been
+        // flushed to the transport.
+        ctx->handshake_cb = NULL;
+        lua_pushboolean(L, 1);
+        return 1;
+    }
+
+    rv = SSL_get_error(ctx->ssl, rv);
+    switch (rv) {
+    case SSL_ERROR_WANT_READ:
+    case SSL_ERROR_WANT_WRITE:
+        lua_pushboolean(L, 0);
+        lua_pushnil(L);
+        lua_pushinteger(L, rv);
+        return 3;
+
+    case SSL_ERROR_ZERO_RETURN:
+        // connection closed
+        return 0;
+
+    default:
+        lua_pushboolean(L, 0);
+        if (ctx->handshake_cb == SSL_connect) {
+            // SSL_connect failure is more likely to be a server-side issue, so
+            // use a different default error message to hint that to users.
+            tls_push_error(L, "SSL_connect",
+                           "failed to initiate SSL/TLS handshake with server");
+        } else {
+            // SSL_accept failure is more likely to be a client-side issue, so
+            // use a different default error message to hint that to users.
+            tls_push_error(L, "SSL_accept",
+                           "failed to initiate SSL/TLS handshake with client");
+        }
+        return 2;
+    }
+}
+
 static int handshake_lua(lua_State *L)
 {
     tls_ctx_t *ctx = luaL_checkudata(L, 1, NET_TLS_CONTEXT_MT);
     int rv         = 0;
 
-    if (!ctx->handshake_cb) {
+    if (!ctx->ssl) {
+        lua_pushboolean(L, 0);
+        lua_errno_new((L), EINVAL, "handshake");
+        return 2;
+    } else if (!ctx->handshake_cb) {
         lua_pushboolean(L, 1);
         return 1;
     }
 
     ERR_clear_error();
+    if (ctx->bio) {
+        return handshake_bio_lua(L, ctx);
+    }
+
     rv = ctx->handshake_cb(ctx->ssl);
     if (rv != 1) {
-        int err = SSL_get_error(ctx->ssl, rv);
-        switch (err) {
+        rv = SSL_get_error(ctx->ssl, rv);
+        switch (rv) {
         case SSL_ERROR_WANT_READ:
         case SSL_ERROR_WANT_WRITE:
             lua_pushboolean(L, 0);
             lua_pushnil(L);
-            lua_pushinteger(L, err);
+            lua_pushinteger(L, rv);
             return 3;
 
         case SSL_ERROR_ZERO_RETURN:
@@ -65,10 +124,10 @@ static int handshake_lua(lua_State *L)
         // error occurred
         lua_pushboolean(L, 0);
         if (ctx->handshake_cb == SSL_connect) {
-            tls_push_error(L, "SSL_connect",
+            tls_push_error(L, "handshake.SSL_connect",
                            "failed to initiate SSL/TLS handshake with server");
         } else {
-            tls_push_error(L, "SSL_accept",
+            tls_push_error(L, "handshake.SSL_accept",
                            "failed to initiate SSL/TLS handshake with client");
         }
         return 2;
@@ -80,21 +139,72 @@ static int handshake_lua(lua_State *L)
     return 1;
 }
 
+static int write_bio_lua(lua_State *L, tls_ctx_t *ctx, const char *buf,
+                         size_t len)
+{
+    // drain first — pending SSL_write may have produced outgoing data that
+    // needs to be sent before we can make progress with the new SSL_write
+
+    ssize_t rv = SSL_write(ctx->ssl, buf, (int)len);
+    if (rv > 0) {
+        // SSL_write always produces ciphertext in txbuf; signal the caller to
+        // drain it so the data actually reaches the peer.
+        lua_pushinteger(L, rv);
+        return 1;
+    }
+
+    rv = SSL_get_error(ctx->ssl, (int)rv);
+    switch (rv) {
+    case SSL_ERROR_WANT_WRITE:
+    case SSL_ERROR_WANT_READ:
+        // buffer is full — drain it to make room for the pending SSL_write
+        lua_pushinteger(L, 0);
+        lua_pushnil(L);
+        lua_pushinteger(L, rv);
+        return 3;
+
+    case SSL_ERROR_ZERO_RETURN:
+        // connection closed
+        return 0;
+
+    default:
+        lua_pushnil(L);
+        tls_push_error(L, "write.SSL_write", "failed to write data");
+        return 2;
+    }
+}
+
 static int write_lua(lua_State *L)
 {
     tls_ctx_t *ctx  = lauxh_checkudata(L, 1, NET_TLS_CONTEXT_MT);
     size_t len      = 0;
     const char *buf = lauxh_checklstring(L, 2, &len);
-    ssize_t rv      = SSL_write(ctx->ssl, buf, len);
+    ssize_t rv      = 0;
 
+    if (!ctx->ssl) {
+        lua_pushnil(L);
+        lua_errno_new(L, EINVAL, "write");
+        return 2;
+    } else if (len == 0) {
+        // nothing to write
+        lua_pushinteger(L, 0);
+        return 1;
+    }
+
+    ERR_clear_error();
+    if (ctx->bio) {
+        return write_bio_lua(L, ctx, buf, len);
+    }
+
+    rv = SSL_write(ctx->ssl, buf, len);
     if (rv <= 0) {
-        int err = SSL_get_error(ctx->ssl, rv);
-        switch (err) {
+        rv = SSL_get_error(ctx->ssl, rv);
+        switch (rv) {
         case SSL_ERROR_WANT_READ:
         case SSL_ERROR_WANT_WRITE:
             lua_pushinteger(L, 0);
             lua_pushnil(L);
-            lua_pushinteger(L, err);
+            lua_pushinteger(L, rv);
             return 3;
 
         case SSL_ERROR_ZERO_RETURN:
@@ -104,12 +214,13 @@ static int write_lua(lua_State *L)
 
         // error occurred
         lua_pushnil(L);
-        tls_push_error(L, "SSL_write", "failed to write data");
+        tls_push_error(L, "write.SSL_write", "failed to write data");
         return 2;
     }
 
     lua_pushinteger(L, rv);
     if ((size_t)rv == len) {
+        // all data was written
         return 1;
     }
     // not all data was written
@@ -118,21 +229,70 @@ static int write_lua(lua_State *L)
     return 3;
 }
 
+static int read_bio_lua(lua_State *L, tls_ctx_t *ctx, char *buf,
+                        lua_Integer bufsiz)
+{
+    ssize_t rv = SSL_read(ctx->ssl, buf, (int)bufsiz);
+    if (rv > 0) {
+        lua_pushlstring(L, buf, (size_t)rv);
+        return 1;
+    }
+
+    rv = SSL_get_error(ctx->ssl, (int)rv);
+    switch (rv) {
+    case SSL_ERROR_WANT_READ:
+    case SSL_ERROR_WANT_WRITE:
+        // need to read data or drain data
+        lua_pushnil(L);
+        lua_pushnil(L);
+        lua_pushinteger(L, rv);
+        return 3;
+
+    case SSL_ERROR_ZERO_RETURN:
+        // connection closed
+        return 0;
+
+    default:
+        lua_pushnil(L);
+        tls_push_error(L, "read.SSL_read", "failed to read data");
+        return 2;
+    }
+}
+
 static int read_lua(lua_State *L)
 {
     tls_ctx_t *ctx     = lauxh_checkudata(L, 1, NET_TLS_CONTEXT_MT);
     lua_Integer bufsiz = lauxh_optinteger(L, 2, BUFSIZ);
-    void *buf          = lua_newuserdata(L, (bufsiz < 0) ? BUFSIZ : bufsiz);
-    ssize_t rv         = SSL_read(ctx->ssl, buf, bufsiz);
+    void *buf          = NULL;
+    ssize_t rv         = 0;
 
+    if (!ctx->ssl) {
+        lua_pushnil(L);
+        lua_errno_new(L, EINVAL, "read");
+        return 2;
+    }
+
+    // bufsiz <= 0 is a special case that means "use a reasonable default buffer
+    // size"
+    if (bufsiz < 0) {
+        bufsiz = BUFSIZ;
+    }
+    buf = lua_newuserdata(L, bufsiz);
+
+    ERR_clear_error();
+    if (ctx->bio) {
+        return read_bio_lua(L, ctx, buf, bufsiz);
+    }
+
+    rv = SSL_read(ctx->ssl, buf, bufsiz);
     if (rv <= 0) {
-        int err = SSL_get_error(ctx->ssl, rv);
-        switch (err) {
+        rv = SSL_get_error(ctx->ssl, rv);
+        switch (rv) {
         case SSL_ERROR_WANT_READ:
         case SSL_ERROR_WANT_WRITE:
             lua_pushnil(L);
             lua_pushnil(L);
-            lua_pushinteger(L, err);
+            lua_pushinteger(L, rv);
             return 3;
 
         case SSL_ERROR_ZERO_RETURN:
@@ -142,7 +302,7 @@ static int read_lua(lua_State *L)
 
         // error occurred
         lua_pushnil(L);
-        tls_push_error(L, "SSL_read", "failed to read data");
+        tls_push_error(L, "read.SSL_read", "failed to read data");
         return 2;
     }
 
@@ -150,21 +310,97 @@ static int read_lua(lua_State *L)
     return 1;
 }
 
+static void cleanup_context(lua_State *L, tls_ctx_t *ctx)
+{
+    if (ctx->ssl) {
+        SSL_free(ctx->ssl); /* also frees rxbio and txbio */
+        ctx->ssl = NULL;
+    }
+    if (ctx->bio) {
+        tls_bio_free(L, ctx->bio);
+        ctx->bio = NULL;
+    }
+    if (ctx->parent_ref != LUA_NOREF) {
+        lauxh_unref(L, ctx->parent_ref);
+        ctx->parent_ref = LUA_NOREF;
+    }
+    ctx->handshake_cb = NULL;
+}
+
+static int close_bio_lua(lua_State *L, tls_ctx_t *ctx)
+{
+    // SSL was fully connected — exchange close_notify with the peer
+    int rv = SSL_shutdown(ctx->ssl);
+    switch (rv) {
+    case 1:
+        // Bidirectional shutdown complete
+        cleanup_context(L, ctx);
+        lua_pushboolean(L, 1);
+        return 1;
+
+    case 0:
+        // Our close_notify was written to txbuf
+        // user needs to send it to the peer and wait for the peer's
+        // close_notify then retry SSL_shutdown to complete the shutdown
+        lua_pushboolean(L, 0);
+        lua_pushnil(L);
+        lua_pushinteger(L, SSL_ERROR_WANT_WRITE);
+        return 3;
+    }
+
+    // rv < 0 indicates an error; determine if it's retryable or fatal
+    rv = SSL_get_error(ctx->ssl, rv);
+    switch (rv) {
+    case SSL_ERROR_WANT_WRITE:
+        lua_pushboolean(L, 0);
+        lua_pushnil(L);
+        lua_pushinteger(L, rv);
+        return 3;
+
+    case SSL_ERROR_WANT_READ:
+        // Drain any pending TX before waiting for the peer's close_notify;
+        // otherwise we deadlock if our close_notify hasn't been sent yet.
+        lua_pushboolean(L, 0);
+        lua_pushnil(L);
+        lua_pushinteger(
+            L, tls_bio_tx_size(ctx->bio) > 0 ? SSL_ERROR_WANT_WRITE : rv);
+        return 3;
+
+    default:
+        /* Other SSL error: free and report */
+        cleanup_context(L, ctx);
+        lua_pushboolean(L, 0);
+        tls_push_error(L, "close.SSL_shutdown",
+                       "failed to shutdown SSL context");
+        return 2;
+    }
+}
+
 static int close_lua(lua_State *L)
 {
     tls_ctx_t *ctx     = lauxh_checkudata(L, 1, NET_TLS_CONTEXT_MT);
-    SSL *ssl           = ctx->ssl;
     const char *errop  = NULL;
     const char *errmsg = NULL;
 
-    if (!ssl) {
+    if (!ctx->ssl) {
+        lua_pushboolean(L, 1);
+        return 1;
+    } else if (ctx->handshake_cb) {
+        // if handshake_cb is not NULL, the handshake is not complete and the
+        // peer won't have any state about this connection, so we can just free
+        // the SSL context without doing SSL_shutdown.
+        cleanup_context(L, ctx);
         lua_pushboolean(L, 1);
         return 1;
     }
 
+    ERR_clear_error();
+    if (ctx->bio) {
+        return close_bio_lua(L, ctx);
+    }
+
     if (!ctx->handshake_cb) {
-        // SSL context should be gracefully shutdown
-        int rv = SSL_shutdown(ssl);
+        int rv = SSL_shutdown(ctx->ssl);
         if (rv < 0) {
             rv = SSL_get_error(ctx->ssl, rv);
             switch (rv) {
@@ -176,17 +412,14 @@ static int close_lua(lua_State *L)
                 return 3;
 
             default:
-                errop  = "SSL_shutdown";
+                errop  = "close.SSL_shutdown";
                 errmsg = "failed to shutdown SSL context";
             }
         }
     }
-    // free ssl context and server reference
-    ctx->ssl          = NULL;
-    ctx->handshake_cb = NULL;
-    SSL_free(ssl);
-    ctx->parent_ref = lauxh_unref(L, ctx->parent_ref);
 
+    // free ssl context and server reference
+    cleanup_context(L, ctx);
     lua_pushboolean(L, 1);
     if (!errop) {
         return 1;
@@ -194,6 +427,22 @@ static int close_lua(lua_State *L)
     // error occurred during SSL_shutdown
     tls_push_error(L, errop, errmsg);
     return 2;
+}
+
+static int get_bio_lua(lua_State *L)
+{
+    tls_ctx_t *ctx = lauxh_checkudata(L, 1, NET_TLS_CONTEXT_MT);
+
+    if (!ctx->ssl) {
+        lua_pushnil(L);
+        lua_errno_new(L, EINVAL, "get_bio");
+        return 2;
+    } else if (ctx->bio) {
+        lauxh_pushref(L, ctx->bio->ref);
+        return 1;
+    }
+
+    return 0;
 }
 
 static int tostring_lua(lua_State *L)
@@ -205,40 +454,105 @@ static int tostring_lua(lua_State *L)
 static int gc_lua(lua_State *L)
 {
     tls_ctx_t *ctx = luaL_checkudata(L, 1, NET_TLS_CONTEXT_MT);
-    if (ctx->ssl) {
-        SSL_free(ctx->ssl);
-        lauxh_unref(L, ctx->parent_ref);
-    }
+    cleanup_context(L, ctx);
     return 0;
+}
+
+static size_t get_max_encrypted_length(int minv, int maxv)
+{
+    const int versions[] = {
+        TLS1_VERSION,
+        TLS1_1_VERSION,
+        TLS1_2_VERSION,
+        TLS1_3_VERSION,
+    };
+    size_t cap = 0;
+    size_t n   = sizeof(versions) / sizeof(versions[0]);
+
+    for (size_t i = 0; i < n; i++) {
+        int version = versions[i];
+
+        if ((minv <= 0 || version >= minv) && (maxv <= 0 || version <= maxv)) {
+            size_t len = tls_get_encrypted_length(version);
+            if (len > cap) {
+                cap = len;
+            }
+        }
+    }
+
+    if (cap == 0) {
+        return tls_get_encrypted_length(TLS1_2_VERSION);
+    }
+    return cap;
+}
+
+static int encrypted_length_lua(lua_State *L)
+{
+    tls_protocol_t protocol = luaL_checkoption(L, 1, "default", TLS_PROTOCOLS);
+    int minv                = 0;
+    int maxv                = 0;
+
+    tls_get_protocol_vers(protocol, &minv, &maxv);
+    lua_pushinteger(L, (lua_Integer)get_max_encrypted_length(minv, maxv));
+    return 1;
+}
+
+static inline size_t get_bio_bufcap(SSL *ssl, lua_Integer bufcap)
+{
+    size_t mincap = get_max_encrypted_length(SSL_get_min_proto_version(ssl),
+                                             SSL_get_max_proto_version(ssl));
+
+    if (bufcap <= 0 || (size_t)bufcap < mincap) {
+        return mincap;
+    }
+    return (size_t)bufcap;
 }
 
 static int accept_lua(lua_State *L)
 {
     tls_server_t *s    = luaL_checkudata(L, 1, NET_TLS_SERVER_MT);
     int fd             = lauxh_checkinteger(L, 2);
+    int use_bio        = lauxh_optboolean(L, 3, 0);
+    lua_Integer bufcap = lauxh_optinteger(L, 4, 0);
     tls_ctx_t *ctx     = lua_newuserdata(L, sizeof(tls_ctx_t));
     const char *errop  = NULL;
     const char *errmsg = NULL;
-    unsigned long err  = 0;
 
     ctx->handshake_cb = SSL_accept;
     ctx->ssl          = SSL_new(s->ctx);
+    ctx->bio          = NULL;
+    ctx->parent_ref   = LUA_NOREF;
+    lauxh_setmetatable(L, NET_TLS_CONTEXT_MT);
+    ctx->parent_ref = lauxh_refat(L, 1);
+
     if (!ctx->ssl) {
-        errop  = "SSL_new";
+        errop  = "accept.SSL_new";
         errmsg = "failed to create SSL context";
+    } else if (use_bio) {
+        size_t cap = get_bio_bufcap(ctx->ssl, bufcap);
+
+        // if BIOs are used, SSL won't touch the fd directly, so we need to set
+        // up the BIOs to enable the handshake and data exchange to work
+        if (!(ctx->bio = tls_bio_new(L, fd, cap))) {
+            errop  = "accept.tls_bio_new";
+            errmsg = "failed to create tls_bio for SSL context";
+        } else if (tls_bio_setup(ctx->ssl, ctx->bio) != 0) {
+            errop  = "accept.tls_bio_setup";
+            errmsg = "failed to set up BIOs for SSL context";
+        } else {
+            // successfully set up BIOs; ready for handshake
+            return 1;
+        }
     } else if (SSL_set_fd(ctx->ssl, fd) != 1) {
-        errop  = "SSL_set_fd";
+        errop  = "accept.SSL_set_fd";
         errmsg = "failed to set file descriptor";
     } else {
-        lauxh_setmetatable(L, NET_TLS_CONTEXT_MT);
-        ctx->parent_ref = lauxh_refat(L, 1);
+        // successfully set fd for SSL; ready for handshake
         return 1;
     }
 
-    if (ctx->ssl) {
-        SSL_free(ctx->ssl);
-    }
     // error occurred
+    cleanup_context(L, ctx);
     lua_pushnil(L);
     tls_push_error(L, errop, errmsg);
     return 2;
@@ -250,7 +564,7 @@ static int noverify_time_cb(int preverify_ok, X509_STORE_CTX *x509_ctx)
         switch (X509_STORE_CTX_get_error(x509_ctx)) {
         case X509_V_ERR_CERT_HAS_EXPIRED:
         case X509_V_ERR_CERT_NOT_YET_VALID:
-            // ignore expired certificate error
+            /* ignore expired certificate error */
             return 1;
         }
     }
@@ -266,6 +580,8 @@ static int connect_lua(lua_State *L)
     int noverify_name      = lauxh_optboolean(L, 4, 0);
     int noverify_time      = lauxh_optboolean(L, 5, 0);
     int noverify_cert      = lauxh_optboolean(L, 6, 0);
+    int use_bio            = lauxh_optboolean(L, 7, 0);
+    lua_Integer bufcap     = lauxh_optinteger(L, 8, 0);
     tls_ctx_t *ctx         = lua_newuserdata(L, sizeof(tls_ctx_t));
     union {
         struct in_addr ip4;
@@ -276,31 +592,34 @@ static int connect_lua(lua_State *L)
 
     ctx->handshake_cb = SSL_connect;
     ctx->ssl          = SSL_new(c->ctx);
+    ctx->bio          = NULL;
+    ctx->parent_ref   = LUA_NOREF;
+    lauxh_setmetatable(L, NET_TLS_CONTEXT_MT);
+    ctx->parent_ref = lauxh_refat(L, 1);
+
     if (!ctx->ssl) {
-        errop  = "SSL_new";
+        errop  = "connect.SSL_new";
         errmsg = "failed to create SSL context";
         goto FAIL;
-    } else if (SSL_set_fd(ctx->ssl, fd) != 1) {
-        errop  = "SSL_set_fd";
-        errmsg = "failed to set file descriptor";
-        goto FAIL;
     } else if (SSL_set_app_data(ctx->ssl, c) != 1) {
-        errop  = "SSL_set_app_data";
+        errop  = "connect.SSL_set_app_data";
         errmsg = "failed to set app data";
         goto FAIL;
     }
 
+    // if servername is provided and is not an IP address, set it for SNI
+    // and hostname verification
     if (len && inet_pton(AF_INET, servername, &addr) != 1 &&
         inet_pton(AF_INET6, servername, &addr) != 1) {
         // Server Name Indication (SNI) support
         if (SSL_set_tlsext_host_name(ctx->ssl, servername) != 1) {
-            errop  = "SSL_set_tlsext_host_name";
+            errop  = "connect.SSL_set_tlsext_host_name";
             errmsg = "failed to set server name indication (SNI)";
             goto FAIL;
         }
         // hostname verification
         if (!noverify_name && SSL_set1_host(ctx->ssl, servername) != 1) {
-            errop  = "SSL_set1_host";
+            errop  = "connect.SSL_set1_host";
             errmsg = "failed to set hostname for verification";
             goto FAIL;
         }
@@ -317,15 +636,29 @@ static int connect_lua(lua_State *L)
         SSL_set_verify(ctx->ssl, SSL_VERIFY_PEER, NULL);
     }
 
-    lauxh_setmetatable(L, NET_TLS_CONTEXT_MT);
-    ctx->parent_ref = lauxh_refat(L, 1);
-    return 1;
+    if (use_bio) {
+        size_t cap = get_bio_bufcap(ctx->ssl, bufcap);
+        if (!(ctx->bio = tls_bio_new(L, fd, cap))) {
+            errop  = "connect.tls_bio_new";
+            errmsg = "failed to create tls_bio for SSL context";
+        } else if (tls_bio_setup(ctx->ssl, ctx->bio) != 0) {
+            errop  = "connect.tls_bio_setup";
+            errmsg = "failed to set up BIOs for SSL context";
+        } else {
+            // successfully set up BIOs; ready for handshake
+            return 1;
+        }
+    } else if (SSL_set_fd(ctx->ssl, fd) != 1) {
+        errop  = "connect.SSL_set_fd";
+        errmsg = "failed to set file descriptor";
+        goto FAIL;
+    } else {
+        // successfully set fd for SSL; ready for handshake
+        return 1;
+    }
 
 FAIL:
-    // error occurred
-    if (ctx->ssl) {
-        SSL_free(ctx->ssl);
-    }
+    cleanup_context(L, ctx);
     lua_pushnil(L);
     tls_push_error(L, errop, errmsg);
     return 2;
@@ -339,6 +672,7 @@ LUALIB_API int luaopen_net_tls_context(lua_State *L)
         {NULL,         NULL        }
     };
     struct luaL_Reg method[] = {
+        {"get_bio",   get_bio_lua  },
         {"read",      read_lua     },
         {"write",     write_lua    },
         {"close",     close_lua    },
@@ -357,13 +691,15 @@ LUALIB_API int luaopen_net_tls_context(lua_State *L)
     lua_setfield(L, -2, "__index");
     lua_pop(L, 1);
 
-    // initialize
+    lua_errno_loadlib(L);
     tls_init(L);
+    tls_bio_init(L);
 
-    lua_createtable(L, 0, 4);
+    lua_createtable(L, 0, 5);
     lauxh_pushfn2tbl(L, "accept", accept_lua);
     lauxh_pushfn2tbl(L, "connect", connect_lua);
-    // add constants
+    lauxh_pushfn2tbl(L, "encrypted_length", encrypted_length_lua);
+    /* keep constants for backward compatibility with lib/tls.lua */
     lauxh_pushint2tbl(L, "WANT_READ", SSL_ERROR_WANT_READ);
     lauxh_pushint2tbl(L, "WANT_WRITE", SSL_ERROR_WANT_WRITE);
     return 1;

--- a/src/tls_server.c
+++ b/src/tls_server.c
@@ -170,6 +170,11 @@ static int new_lua(lua_State *L)
         goto FAIL;
     }
 
+    // set mode
+    SSL_CTX_clear_mode(s->ctx, SSL_MODE_AUTO_RETRY);
+    SSL_CTX_set_mode(s->ctx, SSL_MODE_ENABLE_PARTIAL_WRITE);
+    SSL_CTX_set_mode(s->ctx, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
+
     // set certificate
     if (SSL_CTX_use_certificate_file(s->ctx, cert, SSL_FILETYPE_PEM) != 1) {
         errop  = "SSL_CTX_use_certificate_file";

--- a/src/zring.h
+++ b/src/zring.h
@@ -1,0 +1,243 @@
+/**
+ *  Copyright (C) 2026 Masatoshi Fukunaga
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to
+ *  deal in the Software without restriction, including without limitation the
+ *  rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef zring_h
+#define zring_h
+
+#include <stddef.h>
+
+/**
+ * @brief Ring buffer backed by externally-provided memory.
+ *
+ * Invariant: `tail == (head + count) % cap`
+ *
+ * The memory region pointed to by @p mem is **not owned** by this structure;
+ * the caller is responsible for its lifetime.
+ */
+typedef struct {
+    size_t cap;   /**< Capacity in bytes (fixed after initialisation). */
+    size_t head;  /**< Read  position in [0, cap). */
+    size_t tail;  /**< Write position in [0, cap). */
+    size_t count; /**< Number of valid bytes currently stored. */
+    void *mem;    /**< Externally-provided backing memory (not owned). */
+} zring_t;
+
+/**
+ * @brief Initialise a ring buffer backed by @p mem of @p cap bytes.
+ *
+ * @p mem must remain valid for the lifetime of the ring buffer.
+ *
+ * @param[out] rb   Ring buffer to initialise.
+ * @param[in]  mem  Backing memory region (must not be NULL, not owned).
+ * @param[in]  cap  Capacity of @p mem in bytes (must be > 0).
+ */
+static inline void zring_init(zring_t *rb, void *mem, size_t cap)
+{
+    *rb = (zring_t){
+        .mem   = mem,
+        .cap   = cap,
+        .head  = 0,
+        .tail  = 0,
+        .count = 0,
+    };
+}
+
+/**
+ * @brief Return the size of the contiguous writable region.
+ *
+ * Computes `min(avail, contig)` where:
+ * - `avail  = cap - count` (total free bytes, possibly split across two
+ *                           regions)
+ * - `contig = cap - tail`  (bytes writable before wrapping to the start)
+ *
+ * Layout when head <= tail (free space may be split in two):
+ * @code
+ *   [0]                                                [cap)
+ *    +---------+===========+---------------------------+
+ *    |  free   |   data    |  free (returned segment)  |
+ *    +---------+===========+---------------------------+
+ *    0        head        tail                         cap
+ *
+ *    avail  = cap - count = (cap - tail) + head  [two disjoint regions]
+ *    contig = cap - tail                          [bytes until end-of-buffer]
+ *    min(avail, contig) = contig  (avail >= contig because head >= 0)
+ * @endcode
+ *
+ * Layout when tail < head (free space is one contiguous region):
+ * @code
+ *   [0]                                                [cap)
+ *    +===========+---------------------------+=========+
+ *    |   data    |  free (returned segment)  |  data   |
+ *    +===========+---------------------------+=========+
+ *    0          tail                        head      cap
+ *
+ *    avail  = head - tail                    [contiguous free bytes]
+ *    contig = cap  - tail                    [bytes until end-of-buffer]
+ *    min(avail, contig) = avail  (avail <= contig because head <= cap)
+ * @endcode
+ *
+ * Use this to check available space without obtaining a pointer.
+ * Returns the same value as the @p len set by zring_space().
+ *
+ * @param[in] rb  Ring buffer.
+ * @return Number of contiguous writable bytes (0 if the buffer is full).
+ */
+static inline size_t zring_space_size(zring_t *rb)
+{
+    size_t avail  = rb->cap - rb->count;
+    size_t contig = rb->cap - rb->tail;
+    return avail < contig ? avail : contig;
+}
+
+/**
+ * @brief Return the size of the contiguous readable region.
+ *
+ * Computes `min(count, contig)` where:
+ * - `count  = rb->count`  (total stored bytes, possibly split across two
+ *                          regions)
+ * - `contig = cap - head` (bytes readable before wrapping to the start)
+ *
+ * Layout when head <= tail (data is one contiguous region):
+ * @code
+ *   [0]                                                [cap)
+ *    +---------+===========================+-----------+
+ *    |  free   |  data (returned segment)  |   free    |
+ *    +---------+===========================+-----------+
+ *    0        head                        tail        cap
+ *
+ *    count  = tail - head                 [contiguous data bytes]
+ *    contig = cap  - head                 [bytes until end-of-buffer]
+ *    min(count, contig) = count  (count <= contig because tail <= cap)
+ * @endcode
+ *
+ * Layout when tail < head (data wraps; first segment ends at cap):
+ * @code
+ *   [0]                                                [cap)
+ *    +===========+-----------+=========================+
+ *    |   data    |   free    |  data (returned segment)|
+ *    +===========+-----------+=========================+
+ *    0          tail        head                      cap
+ *
+ *    count  = (cap - head) + tail         [total data: two segments]
+ *    contig = cap - head                  [bytes until end-of-buffer]
+ *    min(count, contig) = contig  (count >= contig because tail >= 0)
+ * @endcode
+ *
+ * Use this to check available data without obtaining a pointer.
+ * Returns the same value as the @p len set by zring_data().
+ *
+ * @param[in] rb  Ring buffer.
+ * @return Number of contiguous readable bytes (0 if the buffer is empty).
+ */
+static inline size_t zring_data_size(zring_t *rb)
+{
+    size_t contig = rb->cap - rb->head;
+    return rb->count < contig ? rb->count : contig;
+}
+
+/**
+ * @brief Return a pointer to the largest contiguous writable region.
+ *
+ * Only a single contiguous segment is returned per call.
+ * After zring_commit(), call again to obtain any remaining space that wraps
+ * around to the beginning of the buffer.
+ *
+ * @param[in]  rb   Ring buffer.
+ * @param[out] len  Set to zring_space_size(rb); 0 if the buffer is full.
+ * @return Pointer to the start of the writable region, or NULL if full.
+ */
+static inline void *zring_space(zring_t *rb, size_t *len)
+{
+    *len = zring_space_size(rb);
+    if (!*len) {
+        return NULL;
+    }
+    return (char *)rb->mem + rb->tail;
+}
+
+/**
+ * @brief Return a pointer to the largest contiguous readable region.
+ *
+ * Only a single contiguous segment is returned per call.
+ * After zring_consume(), call again to obtain any remaining data that wraps
+ * around to the beginning of the buffer.
+ *
+ * @param[in]  rb   Ring buffer.
+ * @param[out] len  Set to zring_data_size(rb); 0 if the buffer is empty.
+ * @return Pointer to the start of the readable region, or NULL if empty.
+ */
+static inline void *zring_data(zring_t *rb, size_t *len)
+{
+    *len = zring_data_size(rb);
+    if (!*len) {
+        return NULL;
+    }
+    return (char *)rb->mem + rb->head;
+}
+
+/**
+ * @brief Mark @p n bytes as written (advance the write position).
+ *
+ * @p n must not exceed zring_space_size(), i.e. the contiguous writable
+ * segment, not merely the total free capacity.
+ *
+ * @param[in,out] rb  Ring buffer.
+ * @param[in]     n   Number of bytes to commit.
+ * @return 0 on success, -1 if @p n exceeds zring_space_size().
+ */
+static inline int zring_commit(zring_t *rb, size_t n)
+{
+    if (n > zring_space_size(rb)) {
+        return -1;
+    }
+    rb->count += n;
+    rb->tail += n;
+    if (rb->tail >= rb->cap) {
+        rb->tail -= rb->cap;
+    }
+    return 0;
+}
+
+/**
+ * @brief Mark @p n bytes as consumed (advance the read position).
+ *
+ * @p n must not exceed zring_data_size(), i.e. the contiguous readable
+ * segment, not merely the total stored byte count.
+ *
+ * @param[in,out] rb  Ring buffer.
+ * @param[in]     n   Number of bytes to consume.
+ * @return 0 on success, -1 if @p n exceeds zring_data_size().
+ */
+static inline int zring_consume(zring_t *rb, size_t n)
+{
+    if (n > zring_data_size(rb)) {
+        return -1;
+    }
+    rb->count -= n;
+    rb->head += n;
+    if (rb->head >= rb->cap) {
+        rb->head -= rb->cap;
+    }
+    return 0;
+}
+
+#endif /* zring_h */

--- a/test/tls/context_test.lua
+++ b/test/tls/context_test.lua
@@ -1,0 +1,442 @@
+require('luacov')
+local testcase = require('testcase')
+local assert = require('assert')
+local exec = require('exec').execvp
+local socket = require('net.socket')
+local gpoll = require('gpoll')
+local sleep = require('time.sleep')
+local tls_context = require('net.tls.context')
+local new_tls_server = require('net.tls.server')
+local new_tls_client = require('net.tls.client')
+
+local SERVER_CONFIG
+
+-- per-operation I/O timeout (seconds); each WANT wait may take up to this long.
+local DEADLINE = 10
+
+function testcase.before_all()
+    local p = assert(exec('openssl', {
+        'req',
+        '-new',
+        '-newkey',
+        'rsa:2048',
+        '-nodes',
+        '-x509',
+        '-days',
+        '1',
+        '-keyout',
+        'cert.key',
+        '-out',
+        'cert.pem',
+        '-subj',
+        '/C=US/CN=www.example.com',
+    }))
+
+    for line in p.stderr:lines() do
+        print(line)
+    end
+
+    local res = assert(p:close())
+    if res.exit ~= 0 then
+        error('failed to generate cert files')
+    end
+
+    SERVER_CONFIG = {
+        cert = 'cert.pem',
+        key = 'cert.key',
+    }
+end
+
+function testcase.after_all()
+    os.remove('cert.pem')
+    os.remove('cert.key')
+end
+
+function testcase.encrypted_length()
+    assert.equal(tls_context.encrypted_length('default'), 17749)
+    assert.equal(tls_context.encrypted_length('tlsv1'), 17749)
+    assert.equal(tls_context.encrypted_length('tlsv1.0'), 17689)
+    assert.equal(tls_context.encrypted_length('tlsv1.1'), 17705)
+    assert.equal(tls_context.encrypted_length('tlsv1.2'), 17749)
+    assert.equal(tls_context.encrypted_length('tlsv1.3'), 16645)
+end
+
+-- WANT_READ / WANT_WRITE indicate a retryable SSL condition
+local WANT = {[tls_context.WANT_READ] = true, [tls_context.WANT_WRITE] = true}
+
+--- endpoint: wraps a TLS context, its fd and optional memory BIO.
+--- @param ctx net.tls.context
+--- @param name string
+--- @param fd integer
+--- @return table ep
+local function new_ep(ctx, name, fd)
+    return {
+        ctx = ctx,
+        name = name,
+        fd = fd,
+        bio = ctx:get_bio(),
+        closed = false,
+    }
+end
+
+--- Single-side bio pump: flush TX buffer to fd, then fill RX buffer from fd.
+--- No-op when the endpoint has no memory BIO (socket-BIO mode) or is closed.
+--- @param ep table
+local function pump(ep)
+    if ep.closed or not ep.bio then
+        return
+    end
+    local _, err = ep.bio:drain()
+    assert(not err, ep.name .. ':bio:drain: ' .. tostring(err))
+    _, err = ep.bio:fill()
+    assert(not err, ep.name .. ':bio:fill: ' .. tostring(err))
+end
+
+--- Wait for a retryable SSL condition on the endpoint.
+--- With BIO: pump the buffers (the peer is a separate process).
+--- Without BIO: wait until the fd becomes readable / writable.
+--- @param ep table
+--- @param want integer tls_context.WANT_READ / WANT_WRITE
+--- @return boolean ok
+--- @return any err
+local function waitio(ep, want)
+    if ep.bio then
+        pump(ep)
+        return true
+    end
+    if want == tls_context.WANT_READ then
+        return gpoll.wait_readable(ep.fd, DEADLINE)
+    elseif want == tls_context.WANT_WRITE then
+        return gpoll.wait_writable(ep.fd, DEADLINE)
+    end
+    return false, 'unknown want: ' .. tostring(want)
+end
+
+--- Drive the endpoint handshake to completion.
+--- @param ep table
+--- @return boolean ok
+--- @return any err
+local function handshake(ep)
+    while true do
+        local ok, err, want = ep.ctx:handshake()
+        if ok then
+            -- with BIO, flush the final handshake flight to the fd
+            pump(ep)
+            return true
+        elseif want and WANT[want] then
+            local ok2, err2 = waitio(ep, want)
+            if not ok2 then
+                return false, ep.name .. ':handshake:waitio: ' .. tostring(err2)
+            end
+        elseif err then
+            return false, ep.name .. ':handshake: ' .. tostring(err)
+        else
+            -- ZERO_RETURN: peer closed before handshake completed
+            return false, ep.name .. ':handshake: peer closed'
+        end
+    end
+end
+
+--- Verify a write from the endpoint: pump the ciphertext out, then read back
+--- exactly #payload bytes from the peer process' stdout.
+--- @param ep table
+--- @param proc exec.process the peer (its stdout receives our plaintext)
+--- @param payload string
+--- @return boolean ok
+--- @return any err
+local function transfer_write(ep, proc, payload)
+    local sent = 0
+    while sent < #payload do
+        local n, err, want = ep.ctx:write(payload:sub(sent + 1))
+        if n then
+            pump(ep)
+            sent = sent + n
+        elseif want and WANT[want] then
+            local ok, err2 = waitio(ep, want)
+            if not ok then
+                return false, ep.name .. ':write:waitio: ' .. tostring(err2)
+            end
+        elseif err then
+            return false, ep.name .. ':write: ' .. tostring(err)
+        else
+            return false, ep.name .. ':write: peer closed'
+        end
+    end
+
+    proc.stdout:set_timeout(DEADLINE)
+    local got, err = proc.stdout:readn(#payload)
+    if got ~= payload then
+        return false, ep.name .. ':write verify failed (got=' ..
+                   tostring(got) .. ', err=' .. tostring(err) .. ')'
+    end
+    return true
+end
+
+--- Verify a read on the endpoint: feed the peer process' stdin (it encrypts and
+--- sends to us), then read until #payload bytes are decrypted.
+--- @param ep table
+--- @param proc exec.process the peer (its stdin feeds plaintext to us)
+--- @param payload string
+--- @return boolean ok
+--- @return any err
+local function transfer_read(ep, proc, payload)
+    proc.stdin:set_timeout(DEADLINE)
+    local ok, err = proc.stdin:write(payload)
+    if not ok then
+        return false, 'peer stdin:write: ' .. tostring(err)
+    end
+
+    local chunks, total = {}, 0
+    while total < #payload do
+        local s, err2, want = ep.ctx:read(#payload - total)
+        if s then
+            pump(ep)
+            total = total + #s
+            chunks[#chunks + 1] = s
+        elseif want and WANT[want] then
+            local ok2, err3 = waitio(ep, want)
+            if not ok2 then
+                return false, ep.name .. ':read:waitio: ' .. tostring(err3)
+            end
+        elseif err2 then
+            return false, ep.name .. ':read: ' .. tostring(err2)
+        else
+            return false,
+                   ep.name .. ':read: peer closed at ' .. total .. '/' ..
+                       #payload
+        end
+    end
+
+    if table.concat(chunks) ~= payload then
+        return false, ep.name .. ':read verify mismatch'
+    end
+    return true
+end
+
+--- Close the endpoint, draining any remaining BIO ciphertext.
+--- @param ep table
+--- @return boolean ok
+--- @return any err
+local function close_ep(ep)
+    while true do
+        local ok, err, want = ep.ctx:close()
+        if ok then
+            ep.closed = true
+            return true
+        elseif want and WANT[want] then
+            local ok2, err2 = waitio(ep, want)
+            if not ok2 then
+                return false, ep.name .. ':close:waitio: ' .. tostring(err2)
+            end
+        elseif err then
+            return false, ep.name .. ':close: ' .. tostring(err)
+        else
+            ep.closed = true
+            return true
+        end
+    end
+end
+
+--- Find a free TCP port on 127.0.0.1 (probe socket is closed immediately).
+--- @return integer port
+local function free_port()
+    local s = assert(socket.bind_inet_stream('127.0.0.1', 0, true, true))
+    local port = assert(s:getsockname()):port()
+    s:close()
+    return port
+end
+
+--- Start `openssl s_server` bound to 127.0.0.1:port; it exits after 1 client.
+--- @param port integer
+--- @return exec.process proc
+local function start_s_server(port)
+    return exec('openssl', {
+        's_server',
+        '-accept',
+        '127.0.0.1:' .. tostring(port),
+        '-cert',
+        'cert.pem',
+        '-key',
+        'cert.key',
+        '-quiet',
+        '-naccept',
+        '1',
+    })
+end
+
+--- Start `openssl s_client` connecting to 127.0.0.1:port.
+--- -quiet enables -ign_eof and -nocommands (arbitrary payload is safe).
+--- @param port integer
+--- @return exec.process proc
+local function start_s_client(port)
+    return exec('openssl', {
+        's_client',
+        '-connect',
+        '127.0.0.1:' .. tostring(port),
+        '-quiet',
+        '-noservername',
+    })
+end
+
+--- Wait until a server is listening on 127.0.0.1:port.
+--- @param port integer
+--- @return net.socket sock connected socket
+--- @return any err
+local function wait_listen(port)
+    for _ = 1, 200 do
+        local sock = socket.connect_inet_stream('127.0.0.1', port, DEADLINE)
+        if sock then
+            return sock
+        end
+        -- ECONNREFUSED: server not ready yet; back off and retry
+        sleep(0.05)
+    end
+    return nil, 's_server did not start listening on port ' .. tostring(port)
+end
+
+--- Dispose of state (ctx, sockets, peer process) best-effort.
+--- @param state table
+local function cleanup(state)
+    if state.ctx then
+        pcall(function()
+            state.ctx:close()
+        end)
+    end
+    for _, s in ipairs(state.socks or {}) do
+        pcall(function()
+            s:close()
+        end)
+    end
+    if state.proc then
+        pcall(function()
+            state.proc:kill()
+        end)
+        pcall(function()
+            state.proc:close()
+        end)
+    end
+end
+
+--- accept_s_client: tls_context.accept (server side, socket-BIO mode) vs s_client.
+function testcase.accept_s_client()
+    local state = {}
+    local ok, err = pcall(function()
+        local lsock = assert(socket.bind_inet_stream('127.0.0.1', 0, true, true))
+        state.socks = {lsock}
+        assert(lsock:listen())
+        local port = assert(lsock:getsockname()):port()
+
+        state.proc = start_s_client(port)
+        assert(gpoll.wait_readable(lsock:fd(), DEADLINE))
+        local afd = assert(lsock:acceptfd())
+        -- wrap() guarantees non-blocking on platforms where accept() does not
+        -- inherit O_NONBLOCK from the listening socket. Keep the wrapper
+        -- alive so its __gc does not close the fd while the TLS context
+        -- still uses it.
+        local asock = assert(socket.wrap(afd))
+        state.socks[#state.socks + 1] = asock
+        local fd = asock:fd()
+
+        local server = assert(new_tls_server(SERVER_CONFIG.cert, SERVER_CONFIG.key))
+        state.ctx = assert(tls_context.accept(server, fd, false))
+        local ep = new_ep(state.ctx, 'server', fd)
+
+        assert(handshake(ep))
+        assert(transfer_read(ep, state.proc, 'hello from client'))
+        assert(transfer_write(ep, state.proc, 'hello from server'))
+        assert(close_ep(ep))
+    end)
+    cleanup(state)
+    if not ok then
+        error(err)
+    end
+end
+
+--- accept_s_client_bio: tls_context.accept (server side, memory BIO) vs s_client.
+function testcase.accept_s_client_bio()
+    local state = {}
+    local ok, err = pcall(function()
+        local lsock = assert(socket.bind_inet_stream('127.0.0.1', 0, true, true))
+        state.socks = {lsock}
+        assert(lsock:listen())
+        local port = assert(lsock:getsockname()):port()
+
+        state.proc = start_s_client(port)
+        assert(gpoll.wait_readable(lsock:fd(), DEADLINE))
+        local afd = assert(lsock:acceptfd())
+        -- Keep the wrapper alive so its __gc does not close the fd while
+        -- the TLS context still uses it.
+        local asock = assert(socket.wrap(afd))
+        state.socks[#state.socks + 1] = asock
+        local fd = asock:fd()
+
+        local server = assert(new_tls_server(SERVER_CONFIG.cert, SERVER_CONFIG.key))
+        state.ctx = assert(tls_context.accept(server, fd, true, 1))
+        local ep = new_ep(state.ctx, 'server', fd)
+        assert(ep.bio, 'BIO not set on server context')
+        assert.match(tostring(ep.bio), '^net.tls.bio: ', false)
+
+        assert(handshake(ep))
+        -- 'A' avoids s_server/s_client connected-command characters
+        assert(transfer_read(ep, state.proc, string.rep('A', 4096)))
+        assert(transfer_write(ep, state.proc, string.rep('A', 4096)))
+        assert(close_ep(ep))
+    end)
+    cleanup(state)
+    if not ok then
+        error(err)
+    end
+end
+
+--- connect_s_server: tls_context.connect (client side, socket-BIO mode) vs s_server.
+function testcase.connect_s_server()
+    local state = {}
+    local ok, err = pcall(function()
+        local port = free_port()
+        state.proc = start_s_server(port)
+        local csock = assert(wait_listen(port))
+        state.socks = {csock}
+        local fd = csock:fd()
+
+        local client = assert(new_tls_client())
+        state.ctx = assert(tls_context.connect(client, fd, nil, false, false,
+                                               true, false))
+        local ep = new_ep(state.ctx, 'client', fd)
+
+        assert(handshake(ep))
+        assert(transfer_write(ep, state.proc, 'hello from client'))
+        assert(transfer_read(ep, state.proc, 'hello from server'))
+        assert(close_ep(ep))
+    end)
+    cleanup(state)
+    if not ok then
+        error(err)
+    end
+end
+
+--- connect_s_server_bio: tls_context.connect (client side, memory BIO) vs s_server.
+function testcase.connect_s_server_bio()
+    local state = {}
+    local ok, err = pcall(function()
+        local port = free_port()
+        state.proc = start_s_server(port)
+        local csock = assert(wait_listen(port))
+        state.socks = {csock}
+        local fd = csock:fd()
+
+        local client = assert(new_tls_client())
+        state.ctx = assert(tls_context.connect(client, fd, nil, false, false,
+                                               true, true, 1))
+        local ep = new_ep(state.ctx, 'client', fd)
+        assert(ep.bio, 'BIO not set on client context')
+
+        assert(handshake(ep))
+        assert(transfer_write(ep, state.proc, string.rep('A', 4096)))
+        assert(transfer_read(ep, state.proc, string.rep('A', 4096)))
+        assert(close_ep(ep))
+    end)
+    cleanup(state)
+    if not ok then
+        error(err)
+    end
+end

--- a/test/tls/stream/inet_test.lua
+++ b/test/tls/stream/inet_test.lua
@@ -168,7 +168,8 @@ function testcase.accept()
         tlscfg = CLIENT_CONFIG,
     }))
 
-    -- test that accept connection as a net.stream.inet.Socket
+    -- test that the stream layer wraps an accepted TLS connection as a
+    -- net.tls.stream.inet.Socket
     local peer = assert(s:accept())
     assert.match(tostring(peer), '^net.tls.stream.inet.Socket: ', false)
 
@@ -466,3 +467,49 @@ function testcase.server_set_sni_callback()
     s:close()
 end
 
+function testcase.write_read_bio()
+    local host = '127.0.0.1'
+    local s = assert(inet.server.new(host, 0, {
+        reuseaddr = true,
+        reuseport = true,
+        tlscfg = {
+            cert = SERVER_CONFIG.cert,
+            key = SERVER_CONFIG.key,
+            use_bio = true,
+        },
+    }))
+    assert(s:listen())
+    local port = assert(s:getsockname()):port()
+    local msg = 'hello'
+
+    -- test that communicates with write and read in BIO mode
+    local p = fork()
+    if p:is_child() then
+        s:close()
+        local c = assert(inet.client.new(host, port, {
+            tlscfg = {
+                noverify_name = CLIENT_CONFIG.noverify_name,
+                noverify_time = CLIENT_CONFIG.noverify_time,
+                noverify_cert = CLIENT_CONFIG.noverify_cert,
+                use_bio = true,
+            },
+        }))
+        -- verify BIO is active on the client side
+        assert(c.tls_bio ~= nil, 'BIO not set on client')
+        assert(c:write(msg))
+        -- wait for peer to close
+        c:read()
+        c:close()
+        return
+    end
+    local peer = assert(s:accept())
+    assert.match(tostring(peer), '^net.tls.stream.inet.Socket: ', false)
+    -- verify BIO is active on the server side
+    assert(peer.tls_bio ~= nil, 'BIO not set on server peer')
+
+    local rcv = assert(peer:read())
+    assert.equal(rcv, msg)
+    peer:close()
+    s:close()
+    assert(p:wait())
+end

--- a/test/tls/stream/unix_test.lua
+++ b/test/tls/stream/unix_test.lua
@@ -345,3 +345,43 @@ function testcase.sendfd_recvfd()
     assert(s:close())
 end
 
+function testcase.write_read_bio()
+    local s = assert(unix.server.new(PATHNAME, {
+        cert = SERVER_CONFIG.cert,
+        key = SERVER_CONFIG.key,
+        use_bio = true,
+    }))
+    assert(s:listen())
+    local msg = 'hello'
+
+    -- test that communicates with write and read in BIO mode
+    local p = fork()
+    if p:is_child() then
+        s:close()
+        local c = assert(unix.client.new(PATHNAME, {
+            tlscfg = {
+                noverify_name = CLIENT_CONFIG.noverify_name,
+                noverify_time = CLIENT_CONFIG.noverify_time,
+                noverify_cert = CLIENT_CONFIG.noverify_cert,
+                use_bio = true,
+            },
+        }))
+        -- verify BIO is active on the client side
+        assert(c.tls_bio ~= nil, 'BIO not set on client')
+        assert(c:write(msg))
+        -- wait for peer to close
+        c:read()
+        c:close()
+        return
+    end
+    local peer = assert(s:accept())
+    assert.match(tostring(peer), '^net.tls.stream.unix.Socket: ', false)
+    -- verify BIO is active on the server side
+    assert(peer.tls_bio ~= nil, 'BIO not set on server peer')
+
+    local rcv = assert(peer:read())
+    assert.equal(rcv, msg)
+    peer:close()
+    s:close()
+    assert(p:wait())
+end


### PR DESCRIPTION
This pull request introduces support for using memory BIO (Buffered I/O) transport in TLS sockets, enabling more flexible and efficient handling of encrypted data streams. The main changes include the addition of BIO buffer management, updates to the TLS socket lifecycle to integrate BIO operations, and documentation and API updates to expose these new capabilities.

**Memory BIO support and integration:**

- Added a new `tls_bio_t` structure and helper functions in `src/tls_bio.h`/`src/tls_bio.c` to manage memory BIO buffers for both receiving and transmitting encrypted data, including Lua bindings and buffer management logic. [[1]](diffhunk://#diff-ef239f4afbd7e7177c7b174e2d678c7021e392d452733910fef476a7ecf9da11R1-R111) [[2]](diffhunk://#diff-0f6c14e769c60a5db66811ae95af5812ef4e60b0e322a990878564102a77e707R37-R38) [[3]](diffhunk://#diff-0f6c14e769c60a5db66811ae95af5812ef4e60b0e322a990878564102a77e707R59-L58) [[4]](diffhunk://#diff-bc8a079deef767743a9e68f45ebd2caa109d80797509fb290493b6c0357e8cb5R80)
- Updated the TLS socket initialization (`Socket:init`) and server/client connection code to support an optional `use_bio` parameter, storing the BIO object and flag in the socket instance for later use. [[1]](diffhunk://#diff-5dd716a81d9f871f2bc3bf5fe42f1afb4ecc674d830637d193fca5708017700dR62) [[2]](diffhunk://#diff-5dd716a81d9f871f2bc3bf5fe42f1afb4ecc674d830637d193fca5708017700dR74-R80) [[3]](diffhunk://#diff-8704c57c8ca5edd86e6f3197292b939b33cd9da77f53e3b3f5199db6be2accfdL104-R105) [[4]](diffhunk://#diff-8704c57c8ca5edd86e6f3197292b939b33cd9da77f53e3b3f5199db6be2accfdL153-R155) [[5]](diffhunk://#diff-557cca0155f0a4882cdab55ed686a47f5e52b26cb4294840cd10ed73fa0eac54L98-R99) [[6]](diffhunk://#diff-557cca0155f0a4882cdab55ed686a47f5e52b26cb4294840cd10ed73fa0eac54L138-R139) [[7]](diffhunk://#diff-68ef64dd616a9dc357c906a380f69e450460e696d8cce24a538d2c01f8153fbbL40-R40) [[8]](diffhunk://#diff-b9bd3d3f6386328d1f40118981ce8319b5f39c76a39fd6bf7bc46f24e5388422L41-R41)

**TLS socket lifecycle and I/O enhancements:**

- Implemented new `bio_fill` and `bio_drain` methods in `lib/tls.lua` to handle reading from and writing to the BIO buffers, and integrated these into the handshake, close, read, and write methods to ensure encrypted records are properly managed and flushed to the network. [[1]](diffhunk://#diff-e0e185b05f3416aa184a3d4fd79ae4a4444ec10f615d54e05a205383d0b3022bR26-R107) [[2]](diffhunk://#diff-e0e185b05f3416aa184a3d4fd79ae4a4444ec10f615d54e05a205383d0b3022bR117-R132) [[3]](diffhunk://#diff-e0e185b05f3416aa184a3d4fd79ae4a4444ec10f615d54e05a205383d0b3022bR167-L88) [[4]](diffhunk://#diff-e0e185b05f3416aa184a3d4fd79ae4a4444ec10f615d54e05a205383d0b3022bR226-L137) [[5]](diffhunk://#diff-e0e185b05f3416aa184a3d4fd79ae4a4444ec10f615d54e05a205383d0b3022bR290-R311) [[6]](diffhunk://#diff-e0e185b05f3416aa184a3d4fd79ae4a4444ec10f615d54e05a205383d0b3022bR377-R390)
- Modified the polling logic (`poll_wait`) to coordinate BIO buffer draining/filling with network readiness, improving non-blocking TLS operations.

**Protocol and buffer size utilities:**

- Refactored protocol version management and added a utility to calculate the maximum encrypted TLS record length for different protocol versions, enabling safe buffer sizing for memory BIO transport. [[1]](diffhunk://#diff-0f6c14e769c60a5db66811ae95af5812ef4e60b0e322a990878564102a77e707L137-R139) [[2]](diffhunk://#diff-0f6c14e769c60a5db66811ae95af5812ef4e60b0e322a990878564102a77e707L147-R239)

**Documentation and API exposure:**

- Updated `doc/net_tls.md` to document the new `encrypted_length` helper and explain how to safely size memory BIO buffers when using the new `use_bio` option.

These changes together provide robust support for memory BIO transport in the TLS module, improving performance and flexibility for advanced networking scenarios.