### PR TITLE
Add ALPN protocol negotiation support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,6 @@ please see [doc/README.md](doc/README.md).
 
 ## Not Yet Implemented
 
-- ALPN (Application-Layer Protocol Negotiation) support
-- NPN (Next Protocol Negotiation) support
-- OCSP (Online Certificate Status Protocol) Stapling support
 - DTLS support
 - Compiling without TLS support
 

--- a/doc/net_stream_inet_client.md
+++ b/doc/net_stream_inet_client.md
@@ -27,6 +27,7 @@ if the `tlscfg` option is specified, it returns [net.tls.stream.inet.Client](net
             - `secure`: secure cipher list. (same as default)
             - `legacy`: legacy cipher list. (`HIGH:MEDIUM:!aNULL`)
             - `all`: all cipher list. (`ALL:!aNULL:!eNULL`)
+        - `alpn:table?`: array of protocol name strings for ALPN (Application-Layer Protocol Negotiation). (default is `nil`)
         - `session_cache_timeout:integer?`: session cache timeout seconds. (default is `0` that cache is disabled)
         - `session_cache_size:integer?`: session cache size. (default is `SSL_SESSION_CACHE_MAX_SIZE_DEFAULT`)
         - `prefer_client_ciphers:boolean?`: prefer client cipher suites over server cipher suites. (default is `false`)

--- a/doc/net_stream_inet_server.md
+++ b/doc/net_stream_inet_server.md
@@ -31,6 +31,7 @@ if the `tlscfg` option is specified, it returns [net.tls.stream.inet.Server](net
             - `secure`: secure cipher list. (same as default)
             - `legacy`: legacy cipher list. (`HIGH:MEDIUM:!aNULL`)
             - `all`: all cipher list. (`ALL:!aNULL:!eNULL`)
+        - `alpn:table?`: array of protocol name strings for ALPN (Application-Layer Protocol Negotiation). (default is `nil`)
         - `session_cache_timeout:integer?`: session cache timeout seconds. (default is `0` that cache is disabled)
         - `session_cache_size:integer?`: session cache size. (default is `SSL_SESSION_CACHE_MAX_SIZE_DEFAULT`)
 

--- a/doc/net_stream_unix_client.md
+++ b/doc/net_stream_unix_client.md
@@ -26,6 +26,7 @@ if the `tlscfg` option is specified, it returns [net.tls.stream.unix.Client](net
             - `secure`: secure cipher list. (same as default)
             - `legacy`: legacy cipher list. (`HIGH:MEDIUM:!aNULL`)
             - `all`: all cipher list. (`ALL:!aNULL:!eNULL`)
+        - `alpn:table?`: array of protocol name strings for ALPN (Application-Layer Protocol Negotiation). (default is `nil`)
         - `session_cache_timeout:integer?`: session cache timeout seconds. (default is `0` that cache is disabled)
         - `session_cache_size:integer?`: session cache size. (default is `SSL_SESSION_CACHE_MAX_SIZE_DEFAULT`)
         - `prefer_client_ciphers:boolean?`: prefer client cipher suites over server cipher suites. (default is `false`)

--- a/doc/net_stream_unix_server.md
+++ b/doc/net_stream_unix_server.md
@@ -26,6 +26,7 @@ if the `tlscfg` option is specified, it returns [net.tls.stream.unix.Server](net
         - `secure`: secure cipher list. (same as default)
         - `legacy`: legacy cipher list. (`HIGH:MEDIUM:!aNULL`)
         - `all`: all cipher list. (`ALL:!aNULL:!eNULL`)
+    - `alpn:table?`: array of protocol name strings for ALPN (Application-Layer Protocol Negotiation). (default is `nil`)
     - `session_cache_timeout:integer?`: session cache timeout seconds. (default is `0` that cache is disabled)
     - `session_cache_size:integer?`: session cache size. (default is `SSL_SESSION_CACHE_MAX_SIZE_DEFAULT`)
     

--- a/lib/stream/inet.lua
+++ b/lib/stream/inet.lua
@@ -84,6 +84,7 @@ local function new_client(host, port, opts)
 
         -- create tls client context
         local ctx, err = tls_client(opts.tlscfg.protocol, opts.tlscfg.ciphers,
+                                    opts.tlscfg.alpn,
                                     opts.tlscfg.session_cache_timeout,
                                     opts.tlscfg.session_cache_size,
                                     opts.tlscfg.prefer_client_ciphers,
@@ -139,6 +140,7 @@ local function new_server(host, port, opts)
         -- create tls server context
         local ctx, err = tls_server(opts.tlscfg.cert, opts.tlscfg.key,
                                     opts.tlscfg.protocol, opts.tlscfg.ciphers,
+                                    opts.tlscfg.alpn,
                                     opts.tlscfg.session_timeout,
                                     opts.tlscfg.session_cache_size)
         if err then

--- a/lib/stream/unix.lua
+++ b/lib/stream/unix.lua
@@ -78,6 +78,7 @@ local function new_client(pathname, opts)
     elseif opts.tlscfg then
         -- create tls client context
         local ctx, err = tls_client(opts.tlscfg.protocol, opts.tlscfg.ciphers,
+                                    opts.tlscfg.alpn,
                                     opts.tlscfg.session_cache_timeout,
                                     opts.tlscfg.session_cache_size,
                                     opts.tlscfg.prefer_client_ciphers,
@@ -125,7 +126,8 @@ local function new_server(pathname, tlscfg)
     elseif tlscfg then
         -- create tls server context
         local ctx, err = tls_server(tlscfg.cert, tlscfg.key, tlscfg.protocol,
-                                    tlscfg.ciphers, tlscfg.session_timeout,
+                                    tlscfg.ciphers, tlscfg.alpn,
+                                    tlscfg.session_timeout,
                                     tlscfg.session_cache_size)
         if err then
             return nil, err

--- a/lib/tls.lua
+++ b/lib/tls.lua
@@ -213,6 +213,14 @@ function Socket:close()
     return self.sock:close()
 end
 
+--- get_alpn
+--- Returns the protocol negotiated via ALPN, or nil if none was negotiated.
+--- Must be called after the handshake completes.
+--- @return string? protocol
+function Socket:get_alpn()
+    return self.tls:get_alpn()
+end
+
 --- handshake
 --- @return boolean ok
 --- @return any err

--- a/src/tls.h
+++ b/src/tls.h
@@ -40,6 +40,9 @@ typedef struct {
     lua_State *L;
     SSL_CTX *ctx;
     int sni_callback_ref;
+    int ref_alpn;
+    unsigned char *alpn;
+    size_t alpn_len;
 } tls_server_t;
 
 #define NET_TLS_SERVER_MT "net.tls.server"
@@ -51,6 +54,85 @@ typedef struct {
 } tls_client_t;
 
 #define NET_TLS_CLIENT_MT "net.tls.client"
+
+// Convert a Lua array of protocol name strings at stack index idx into the
+// ALPN wire-format list: [len1][name1][len2][name2]... on the stack.
+// The function returns the number of protocols found and replaces the original
+// table with the wire-format string on the stack.
+// Returns >0 if the table contains valid protocols.
+// Returns 0 if the table is nil, empty or contains no valid protocols.
+// Returns -1 on error and leaves an error message on the stack. luaL_error on
+// invalid input (non-string element, >255 bytes).
+static inline int tls_check_alpn_table(lua_State *L, int idx)
+{
+    int n      = 0;
+    int nproto = 0;
+
+    // check if the table is nil or empty
+    if (lua_isnoneornil(L, idx)) {
+        return 0;
+    }
+    luaL_checktype(L, idx, LUA_TTABLE);
+    n = lauxh_rawlen(L, idx);
+    if (n <= 0) {
+        return 0;
+    }
+
+    // confirm stack size can be increased by n elements
+    if (!lua_checkstack(L, n)) {
+        lua_pushliteral(L, "too many alpn protocols, not enough stack space");
+        return -1;
+    }
+
+    // first pass: compute total wire length
+    for (int i = 1; i <= n; i++) {
+        char wire[256]    = {0};
+        size_t plen       = 0;
+        const char *proto = NULL;
+
+        // get the protocol string at index i
+        lua_rawgeti(L, idx, i);
+        // ensure it's a string
+        if (lua_type(L, -1) != LUA_TSTRING) {
+            lua_pop(L, 1);
+            lua_pushfstring(L, "alpn protocol #%d must be a string", i);
+            return -1;
+        }
+
+        // get the length of the protocol string
+        proto = lua_tolstring(L, -1, &plen);
+        if (plen > 255) {
+            lua_pop(L, 1);
+            lua_pushfstring(L, "alpn protocol #%d exceeds 255 bytes", i);
+            return -1;
+        } else if (plen == 0) {
+            // ignore empty protocol strings
+            lua_pop(L, 1);
+            continue;
+        }
+
+        // alpn wire format: [len][name]
+        wire[0] = (char)plen;
+        memcpy(wire + 1, proto, plen);
+        lua_pop(L, 1);
+        lua_pushlstring(L, wire, plen + 1);
+
+        nproto++;
+        // keep the protocol length and name on the stack for building the wire
+        // format later
+    }
+
+    // no valid protocols found
+    if (nproto == 0) {
+        return 0;
+    }
+
+    // concat the protocol lengths and names into the wire format, and replace
+    // the original table with the wire-format string on the stack
+    lua_concat(L, nproto);
+    lua_replace(L, idx);
+    return nproto;
+}
 
 typedef int (*tls_handshake_fn)(SSL *);
 
@@ -78,8 +160,8 @@ static inline void tls_init(lua_State *L)
     lua_error_loadlib(L, 1);
 }
 
-// NOTE: the cleanup process should not be performed if the OpenSSL library has
-// been initialized outside of this module, as it may not work properly.
+// NOTE: the cleanup process should not be performed if the OpenSSL library
+// has been initialized outside of this module, as it may not work properly.
 // static inline void cleanup_openssl(void)
 // {
 // #if OPENSSL_VERSION_NUMBER < 0x10100000L
@@ -225,7 +307,8 @@ static inline size_t tls_get_encrypted_length(int version)
                TLS_LEGACY_MAX_MAC_LENGTH + TLS_MAX_PADDING_LENGTH;
 
     case TLS1_3_VERSION:
-        /* overhead = AEAD tag (16) + inner type (1) + padding (up to 239) */
+        /* overhead = AEAD tag (16) + inner type (1) + padding (up to 239)
+         */
         return TLS_RECORD_HEADER_LENGTH + TLS_MAX_PLAIN_LENGTH +
                TLS13_MAX_OVERHEAD;
 

--- a/src/tls_client.c
+++ b/src/tls_client.c
@@ -301,6 +301,7 @@ static void print_error(tls_client_t *c, const char *op, const char *errmsg)
 // TLS handshake verification callback for stapled requests
 static int ocsp_verify_cb(SSL *ssl, void *arg)
 {
+    (void)arg;
     tls_client_t *c       = SSL_get_app_data(ssl);
     ocsp_verify_ctx_t ctx = {0};
     int rc                = verify_ocsp_response(&ctx, ssl);
@@ -341,17 +342,26 @@ static int new_lua(lua_State *L)
     int narg          = lua_gettop(L);
     int protocol      = luaL_checkoption(L, 1, "default", TLS_PROTOCOLS);
     int cipher        = luaL_checkoption(L, 2, "default", TLS_CIPHER_SUITES);
-    int cache_timeout = lauxh_optinteger(L, 3, 0);
-    int cache_size = lauxh_optinteger(L, 4, SSL_SESSION_CACHE_MAX_SIZE_DEFAULT);
-    int prefer_client_ciphers = lauxh_optboolean(L, 5, 0);
+    int cache_timeout = lauxh_optinteger(L, 4, 0);
+    int cache_size = lauxh_optinteger(L, 5, SSL_SESSION_CACHE_MAX_SIZE_DEFAULT);
+    int prefer_client_ciphers = lauxh_optboolean(L, 6, 0);
+    int nalpn                 = 0;
     tls_client_t *c           = NULL;
     const char *errop         = NULL;
     const char *errmsg        = NULL;
 
+    // check ALPN table parsing error
+    nalpn = tls_check_alpn_table(L, 3);
+    if (nalpn < 0) {
+        errop  = "tls_check_alpn_table";
+        errmsg = lua_tostring(L, -1);
+        goto FAIL;
+    }
+
     // check error function
-    if (narg >= 6 && !lua_isnoneornil(L, 6)) {
-        luaL_checktype(L, 6, LUA_TFUNCTION);
-        lua_settop(L, 6);
+    if (narg >= 7 && !lua_isnoneornil(L, 7)) {
+        luaL_checktype(L, 7, LUA_TFUNCTION);
+        lua_settop(L, 7);
     }
 
     // create context
@@ -420,9 +430,20 @@ static int new_lua(lua_State *L)
         goto FAIL;
     }
 
+    // configure ALPN (OpenSSL copies the list internally)
+    if (nalpn > 0) {
+        size_t len          = 0;
+        unsigned char *alpn = (unsigned char *)lua_tolstring(L, 3, &len);
+        if (SSL_CTX_set_alpn_protos(c->ctx, alpn, (unsigned int)len) != 0) {
+            errop  = "SSL_CTX_set_alpn_protos";
+            errmsg = "failed to set ALPN protocols";
+            goto FAIL;
+        }
+    }
+
     // keep error function reference
-    if (narg >= 6) {
-        c->error_cb_ref = lauxh_refat(L, 6);
+    if (narg >= 7) {
+        c->error_cb_ref = lauxh_refat(L, 7);
     }
 
     // return net.tls.client userdata
@@ -430,7 +451,7 @@ static int new_lua(lua_State *L)
     return 1;
 
 FAIL:
-    if (c->ctx) {
+    if (c && c->ctx) {
         SSL_CTX_free(c->ctx);
     }
     lua_pushnil(L);

--- a/src/tls_context.c
+++ b/src/tls_context.c
@@ -445,6 +445,27 @@ static int get_bio_lua(lua_State *L)
     return 0;
 }
 
+static int get_alpn_lua(lua_State *L)
+{
+    tls_ctx_t *ctx            = lauxh_checkudata(L, 1, NET_TLS_CONTEXT_MT);
+    const unsigned char *data = NULL;
+    unsigned int len          = 0;
+
+    if (!ctx->ssl) {
+        lua_pushnil(L);
+        lua_errno_new(L, EINVAL, "get_alpn");
+        return 2;
+    }
+
+    SSL_get0_alpn_selected(ctx->ssl, &data, &len);
+    if (len == 0) {
+        // no ALPN was negotiated
+        return 0;
+    }
+    lua_pushlstring(L, (const char *)data, len);
+    return 1;
+}
+
 static int tostring_lua(lua_State *L)
 {
     lua_pushfstring(L, NET_TLS_CONTEXT_MT ": %p", lua_touserdata(L, 1));
@@ -672,6 +693,7 @@ LUALIB_API int luaopen_net_tls_context(lua_State *L)
         {NULL,         NULL        }
     };
     struct luaL_Reg method[] = {
+        {"get_alpn",  get_alpn_lua },
         {"get_bio",   get_bio_lua  },
         {"read",      read_lua     },
         {"write",     write_lua    },

--- a/src/tls_server.c
+++ b/src/tls_server.c
@@ -130,12 +130,30 @@ static int tostring_lua(lua_State *L)
     return 1;
 }
 
+static int alpn_select_cb(SSL *ssl, const unsigned char **out,
+                          unsigned char *outlen, const unsigned char *client,
+                          unsigned int client_len, void *arg)
+{
+    (void)ssl;
+    tls_server_t *s = (tls_server_t *)arg;
+    if (!s->alpn || s->alpn_len == 0) {
+        return SSL_TLSEXT_ERR_NOACK;
+    }
+    if (SSL_select_next_proto((unsigned char **)out, outlen, s->alpn,
+                              s->alpn_len, client,
+                              client_len) == OPENSSL_NPN_NEGOTIATED) {
+        return SSL_TLSEXT_ERR_OK;
+    }
+    return SSL_TLSEXT_ERR_NOACK;
+}
+
 static int gc_lua(lua_State *L)
 {
     tls_server_t *s = luaL_checkudata(L, 1, NET_TLS_SERVER_MT);
     SSL_CTX_set_tlsext_servername_callback(s->ctx, NULL);
     SSL_CTX_set_tlsext_servername_arg(s->ctx, NULL);
     s->sni_callback_ref = lauxh_unref(L, s->sni_callback_ref);
+    s->ref_alpn         = lauxh_unref(L, s->ref_alpn);
     SSL_CTX_free(s->ctx);
     return 0;
 }
@@ -154,15 +172,28 @@ static int new_lua(lua_State *L)
     const char *key  = luaL_checkstring(L, 2);
     int protocol     = luaL_checkoption(L, 3, "default", TLS_PROTOCOLS);
     int cipher_suite = luaL_checkoption(L, 4, "default", TLS_CIPHER_SUITES);
-    lua_Integer sess_timout = luaL_optinteger(L, 5, 300);
-    lua_Integer sess_cache  = luaL_optinteger(L, 6, 1024 * 20);
-    tls_server_t *s         = lua_newuserdata(L, sizeof(tls_server_t));
+    int nalpn        = 0;
+    lua_Integer sess_timout = luaL_optinteger(L, 6, 300);
+    lua_Integer sess_cache  = luaL_optinteger(L, 7, 1024 * 20);
+    tls_server_t *s         = NULL;
     const char *errop       = NULL;
     const char *errmsg      = NULL;
 
+    // check ALPN table argument
+    nalpn = tls_check_alpn_table(L, 5);
+    if (nalpn < 0) {
+        errop  = "tls_check_alpn_table";
+        errmsg = lua_tostring(L, -1);
+        goto FAIL;
+    }
+
     // create context
+    s                   = lua_newuserdata(L, sizeof(tls_server_t));
     s->L                = L;
     s->sni_callback_ref = LUA_NOREF;
+    s->alpn             = NULL;
+    s->alpn_len         = 0;
+    s->ref_alpn         = LUA_NOREF;
     s->ctx              = SSL_CTX_new(TLS_server_method());
     if (!s->ctx) {
         errop  = "SSL_CTX_new";
@@ -216,11 +247,19 @@ static int new_lua(lua_State *L)
     // prefer server cipher suites over client cipher suites
     SSL_CTX_set_options(s->ctx, SSL_OP_CIPHER_SERVER_PREFERENCE);
 
+    // configure ALPN (Application-Layer Protocol Negotiation)
+    if (nalpn > 0) {
+        s->alpn     = (unsigned char *)lua_tolstring(L, 5, &s->alpn_len);
+        s->alpn_len = (unsigned int)s->alpn_len;
+        s->ref_alpn = lauxh_refat(L, 5);
+        SSL_CTX_set_alpn_select_cb(s->ctx, alpn_select_cb, s);
+    }
+
     lauxh_setmetatable(L, NET_TLS_SERVER_MT);
     return 1;
 
 FAIL:
-    if (s->ctx) {
+    if (s && s->ctx) {
         SSL_CTX_free(s->ctx);
     }
     lua_pushnil(L);

--- a/test/tls/context_test.lua
+++ b/test/tls/context_test.lua
@@ -62,7 +62,10 @@ function testcase.encrypted_length()
 end
 
 -- WANT_READ / WANT_WRITE indicate a retryable SSL condition
-local WANT = {[tls_context.WANT_READ] = true, [tls_context.WANT_WRITE] = true}
+local WANT = {
+    [tls_context.WANT_READ] = true,
+    [tls_context.WANT_WRITE] = true,
+}
 
 --- endpoint: wraps a TLS context, its fd and optional memory BIO.
 --- @param ctx net.tls.context
@@ -166,8 +169,9 @@ local function transfer_write(ep, proc, payload)
     proc.stdout:set_timeout(DEADLINE)
     local got, err = proc.stdout:readn(#payload)
     if got ~= payload then
-        return false, ep.name .. ':write verify failed (got=' ..
-                   tostring(got) .. ', err=' .. tostring(err) .. ')'
+        return false,
+               ep.name .. ':write verify failed (got=' .. tostring(got) ..
+                   ', err=' .. tostring(err) .. ')'
     end
     return true
 end
@@ -201,8 +205,7 @@ local function transfer_read(ep, proc, payload)
         elseif err2 then
             return false, ep.name .. ':read: ' .. tostring(err2)
         else
-            return false,
-                   ep.name .. ':read: peer closed at ' .. total .. '/' ..
+            return false, ep.name .. ':read: peer closed at ' .. total .. '/' ..
                        #payload
         end
     end
@@ -249,8 +252,8 @@ end
 --- Start `openssl s_server` bound to 127.0.0.1:port; it exits after 1 client.
 --- @param port integer
 --- @return exec.process proc
-local function start_s_server(port)
-    return exec('openssl', {
+local function start_s_server(port, alpn)
+    local args = {
         's_server',
         '-accept',
         '127.0.0.1:' .. tostring(port),
@@ -261,21 +264,31 @@ local function start_s_server(port)
         '-quiet',
         '-naccept',
         '1',
-    })
+    }
+    if alpn then
+        args[#args + 1] = '-alpn'
+        args[#args + 1] = alpn
+    end
+    return exec('openssl', args)
 end
 
 --- Start `openssl s_client` connecting to 127.0.0.1:port.
 --- -quiet enables -ign_eof and -nocommands (arbitrary payload is safe).
 --- @param port integer
 --- @return exec.process proc
-local function start_s_client(port)
-    return exec('openssl', {
+local function start_s_client(port, alpn)
+    local args = {
         's_client',
         '-connect',
         '127.0.0.1:' .. tostring(port),
         '-quiet',
         '-noservername',
-    })
+    }
+    if alpn then
+        args[#args + 1] = '-alpn'
+        args[#args + 1] = alpn
+    end
+    return exec('openssl', args)
 end
 
 --- Wait until a server is listening on 127.0.0.1:port.
@@ -321,8 +334,11 @@ end
 function testcase.accept_s_client()
     local state = {}
     local ok, err = pcall(function()
-        local lsock = assert(socket.bind_inet_stream('127.0.0.1', 0, true, true))
-        state.socks = {lsock}
+        local lsock =
+            assert(socket.bind_inet_stream('127.0.0.1', 0, true, true))
+        state.socks = {
+            lsock,
+        }
         assert(lsock:listen())
         local port = assert(lsock:getsockname()):port()
 
@@ -337,7 +353,8 @@ function testcase.accept_s_client()
         state.socks[#state.socks + 1] = asock
         local fd = asock:fd()
 
-        local server = assert(new_tls_server(SERVER_CONFIG.cert, SERVER_CONFIG.key))
+        local server = assert(new_tls_server(SERVER_CONFIG.cert,
+                                             SERVER_CONFIG.key))
         state.ctx = assert(tls_context.accept(server, fd, false))
         local ep = new_ep(state.ctx, 'server', fd)
 
@@ -356,8 +373,11 @@ end
 function testcase.accept_s_client_bio()
     local state = {}
     local ok, err = pcall(function()
-        local lsock = assert(socket.bind_inet_stream('127.0.0.1', 0, true, true))
-        state.socks = {lsock}
+        local lsock =
+            assert(socket.bind_inet_stream('127.0.0.1', 0, true, true))
+        state.socks = {
+            lsock,
+        }
         assert(lsock:listen())
         local port = assert(lsock:getsockname()):port()
 
@@ -370,7 +390,8 @@ function testcase.accept_s_client_bio()
         state.socks[#state.socks + 1] = asock
         local fd = asock:fd()
 
-        local server = assert(new_tls_server(SERVER_CONFIG.cert, SERVER_CONFIG.key))
+        local server = assert(new_tls_server(SERVER_CONFIG.cert,
+                                             SERVER_CONFIG.key))
         state.ctx = assert(tls_context.accept(server, fd, true, 1))
         local ep = new_ep(state.ctx, 'server', fd)
         assert(ep.bio, 'BIO not set on server context')
@@ -395,7 +416,9 @@ function testcase.connect_s_server()
         local port = free_port()
         state.proc = start_s_server(port)
         local csock = assert(wait_listen(port))
-        state.socks = {csock}
+        state.socks = {
+            csock,
+        }
         local fd = csock:fd()
 
         local client = assert(new_tls_client())
@@ -421,7 +444,9 @@ function testcase.connect_s_server_bio()
         local port = free_port()
         state.proc = start_s_server(port)
         local csock = assert(wait_listen(port))
-        state.socks = {csock}
+        state.socks = {
+            csock,
+        }
         local fd = csock:fd()
 
         local client = assert(new_tls_client())
@@ -439,4 +464,100 @@ function testcase.connect_s_server_bio()
     if not ok then
         error(err)
     end
+end
+
+--- accept_s_client_alpn: ALPN negotiation on the server side vs s_client.
+function testcase.accept_s_client_alpn()
+    local state = {}
+    local ok, err = pcall(function()
+        local lsock =
+            assert(socket.bind_inet_stream('127.0.0.1', 0, true, true))
+        state.socks = {
+            lsock,
+        }
+        assert(lsock:listen())
+        local port = assert(lsock:getsockname()):port()
+
+        state.proc = start_s_client(port, 'h2')
+        assert(gpoll.wait_readable(lsock:fd(), DEADLINE))
+        local afd = assert(lsock:acceptfd())
+        local asock = assert(socket.wrap(afd))
+        state.socks[#state.socks + 1] = asock
+        local fd = asock:fd()
+
+        local server = assert(new_tls_server(SERVER_CONFIG.cert,
+                                             SERVER_CONFIG.key, 'default',
+                                             'default', {
+            'h2',
+        }, 300, 512))
+        state.ctx = assert(tls_context.accept(server, fd, false))
+        local ep = new_ep(state.ctx, 'server', fd)
+
+        assert(handshake(ep))
+        assert.equal(ep.ctx:get_alpn(), 'h2')
+        assert(close_ep(ep))
+    end)
+    cleanup(state)
+    if not ok then
+        error(err)
+    end
+end
+
+--- connect_s_server_alpn: ALPN negotiation on the client side vs s_server.
+function testcase.connect_s_server_alpn()
+    local state = {}
+    local ok, err = pcall(function()
+        local port = free_port()
+        state.proc = start_s_server(port, 'h2')
+        local csock = assert(wait_listen(port))
+        state.socks = {
+            csock,
+        }
+        local fd = csock:fd()
+
+        local client = assert(new_tls_client('default', 'default', {
+            'h2',
+        }, 0, 0, false))
+        state.ctx = assert(tls_context.connect(client, fd, nil, false, false,
+                                               true, false))
+        local ep = new_ep(state.ctx, 'client', fd)
+
+        assert(handshake(ep))
+        assert.equal(ep.ctx:get_alpn(), 'h2')
+        assert(close_ep(ep))
+    end)
+    cleanup(state)
+    if not ok then
+        error(err)
+    end
+end
+
+--- new_server_alpn_invalid: invalid ALPN tables must be rejected.
+function testcase.new_server_alpn_invalid()
+    -- non-string element
+    local ctx, err = new_tls_server(SERVER_CONFIG.cert, SERVER_CONFIG.key,
+                                     'default', 'default', {123})
+    assert(ctx == nil, 'should reject non-string ALPN element')
+    assert(err, 'should return error')
+
+    -- protocol name exceeding 255 bytes
+    ctx, err = new_tls_server(SERVER_CONFIG.cert, SERVER_CONFIG.key,
+                              'default', 'default',
+                              {string.rep('x', 256)})
+    assert(ctx == nil, 'should reject >255 byte ALPN protocol')
+    assert(err, 'should return error')
+end
+
+--- new_client_alpn_invalid: invalid ALPN tables must be rejected.
+function testcase.new_client_alpn_invalid()
+    -- non-string element
+    local ctx, err = new_tls_client('default', 'default', {123})
+    assert(ctx == nil, 'should reject non-string ALPN element')
+    assert(err, 'should return error')
+
+    -- protocol name exceeding 255 bytes
+    ctx, err = new_tls_client('default', 'default',
+                              {string.rep('x', 256)})
+    assert(ctx == nil, 'should reject >255 byte ALPN protocol')
+    assert(err, 'should return error')
 end


### PR DESCRIPTION
This pull request adds support for ALPN (Application-Layer Protocol Negotiation) in both the client and server TLS contexts. It introduces new options for specifying ALPN protocol lists, updates the documentation accordingly, and implements the necessary logic to handle ALPN negotiation and retrieval in the Lua and C code. Additionally, it cleans up and improves error handling and memory management related to ALPN.

**ALPN Support Implementation**

* Added `alpn` option to the TLS configuration for both client and server, allowing an array of protocol name strings to be specified for ALPN negotiation. This is reflected in the documentation for all relevant modules (`doc/net_stream_inet_client.md`, `doc/net_stream_inet_server.md`, `doc/net_stream_unix_client.md`, `doc/net_stream_unix_server.md`). [[1]](diffhunk://#diff-5c7aee89bfc3b94e8149d19d6058cd0cf0196ef612aefb37f48ac33c7bed5af6R30) [[2]](diffhunk://#diff-f12c0f15d5201e9dd5529d654b478f862b0748be1aec721ef3ad213b25d9705aR34) [[3]](diffhunk://#diff-a0aec9fb6845cdfe738e06786df65404365426fdb6e089ea454440ca8ebdf7ffR29) [[4]](diffhunk://#diff-190c21f7bcd8a1a13c6ddfc941b683f7e9b876a6fa6fa06935e38f304d13f65bR29)
* Updated the Lua code in `lib/stream/inet.lua` and `lib/stream/unix.lua` to pass the `alpn` option through to the TLS context creation functions. [[1]](diffhunk://#diff-8704c57c8ca5edd86e6f3197292b939b33cd9da77f53e3b3f5199db6be2accfdR87) [[2]](diffhunk://#diff-8704c57c8ca5edd86e6f3197292b939b33cd9da77f53e3b3f5199db6be2accfdR143) [[3]](diffhunk://#diff-557cca0155f0a4882cdab55ed686a47f5e52b26cb4294840cd10ed73fa0eac54R81) [[4]](diffhunk://#diff-557cca0155f0a4882cdab55ed686a47f5e52b26cb4294840cd10ed73fa0eac54L128-R130)
* Implemented ALPN wire-format parsing and validation in C (`tls_check_alpn_table` in `src/tls.h`), and integrated it into the TLS client and server context creation logic. [[1]](diffhunk://#diff-0f6c14e769c60a5db66811ae95af5812ef4e60b0e322a990878564102a77e707R58-R136) [[2]](diffhunk://#diff-910a4c21211f43f58b72e5d6b78803203bc9f05edf868b31d2497aef9a28accdL344-R364) [[3]](diffhunk://#diff-f296796deff8179cb1c1e1d4a007f8fdb543eb66f648049990840c9e2f1689b0L157-R196)

**ALPN Negotiation and Retrieval**

* For the client: Configured the ALPN protocol list using `SSL_CTX_set_alpn_protos` and added error handling for ALPN setup failures in `src/tls_client.c`.
* For the server: Implemented ALPN selection callback (`alpn_select_cb`) and ensured proper memory management for ALPN protocol lists in `src/tls_server.c`. [[1]](diffhunk://#diff-f296796deff8179cb1c1e1d4a007f8fdb543eb66f648049990840c9e2f1689b0R133-R156) [[2]](diffhunk://#diff-f296796deff8179cb1c1e1d4a007f8fdb543eb66f648049990840c9e2f1689b0R250-R262)

**ALPN API Exposure**

* Exposed a new `get_alpn` method in the Lua API (`lib/tls.lua`, `src/tls_context.c`) to retrieve the negotiated ALPN protocol after handshake completion. [[1]](diffhunk://#diff-e0e185b05f3416aa184a3d4fd79ae4a4444ec10f615d54e05a205383d0b3022bR216-R223) [[2]](diffhunk://#diff-536836db70b2c8f8fbe38b8c578da84a6b0409d9f179eed344c08e7f7e961839R448-R468) [[3]](diffhunk://#diff-536836db70b2c8f8fbe38b8c578da84a6b0409d9f179eed344c08e7f7e961839R696)

**Documentation and Not Yet Implemented List**

* Updated the `README.md` to remove ALPN from the "Not Yet Implemented" list, reflecting its implementation in this PR.