### PR TITLE
Return symbolic names from addrinfo accessors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ _*
 *.crt
 *.pem
 *.p12
-/src/config.h
+coverage/
+config.h

--- a/covgen.sh
+++ b/covgen.sh
@@ -4,6 +4,5 @@ set -ex
 
 mkdir -p ./coverage
 lcov -c -d ./src -o coverage/lcov.info.all
-lcov -r coverage/lcov.info.all '*/include/*' -o coverage/lcov.info.all
-lcov -r coverage/lcov.info.all '*/deps/*' -o coverage/lcov.info
-# genhtml -o coverage/html coverage/lcov.info
+lcov -r coverage/lcov.info.all '*/include/*' -o coverage/lcov.info
+#genhtml -o coverage/html coverage/lcov.info

--- a/rockspecs/net-scm-1.rockspec
+++ b/rockspecs/net-scm-1.rockspec
@@ -59,7 +59,10 @@ build = {
     modules = {
         net = "net.lua",
         ["net.addrinfo"] = {
-            sources = "src/addrinfo.c",
+            sources = {
+                "src/addrinfo.c",
+                "src/constants.c",
+            },
             incdirs = {
                 "src",
                 "$(DEP_ERROR_INCDIR)",

--- a/src/addrinfo.c
+++ b/src/addrinfo.c
@@ -491,48 +491,6 @@ static int gc_lua(lua_State *L)
     return 0;
 }
 
-/**
- * @brief Allocate a net.addrinfo userdata that owns copies of `src`'s
- * sockaddr and canonical name.
- *
- * The sockaddr is copied into a Lua-managed sockaddr_storage userdata and
- * kept alive with a registry reference so the returned addrinfo stays valid
- * after the caller frees the source list.  The canonical name, if present,
- * is copied into a Lua string that is likewise referenced from the userdata.
- *
- * @param L Lua state.
- * @param src Source addrinfo whose contents are copied.
- * @return Pointer to the newly pushed net_addrinfo_t userdata.
- */
-static inline net_addrinfo_t *new_addrinfo(lua_State *L, struct addrinfo *src)
-{
-    net_addrinfo_t *info = lua_newuserdata(L, sizeof(net_addrinfo_t));
-
-    info->ai_addr_ref      = LUA_NOREF;
-    info->ai_canonname_ref = LUA_NOREF;
-    lauxh_setmetatable(L, NET_ADDRINFO_MT);
-
-    // copy data
-    memcpy((void *)&info->ai, (void *)src, sizeof(struct addrinfo));
-    info->ai.ai_addr  = lua_newuserdata(L, sizeof(struct sockaddr_storage));
-    info->ai_addr_ref = lauxh_ref(L);
-
-    // copy sockaddr data
-    info->ai.ai_addrlen = src->ai_addrlen;
-    memcpy((void *)info->ai.ai_addr, (void *)src->ai_addr, src->ai_addrlen);
-
-    // copy canonname data
-    info->ai.ai_canonname  = NULL;
-    info->ai_canonname_ref = LUA_NOREF;
-    if (src->ai_canonname) {
-        lua_pushstring(L, src->ai_canonname);
-        info->ai.ai_canonname  = (char *)lua_tostring(L, -1);
-        info->ai_canonname_ref = lauxh_ref(L);
-    }
-
-    return info;
-}
-
 // ---------------------------------------------------------------------------
 // getaddrinfo family
 // ---------------------------------------------------------------------------
@@ -596,7 +554,7 @@ static int parse_host_port(lua_State *L, const char **host, const char **serv,
 /**
  * @brief Protected worker for do_getaddrinfo.  Builds the result table by
  * iterating the addrinfo list carried in upvalue 1 (as a lightuserdata) and
- * calling new_addrinfo for each entry.  Runs under lua_pcall so an OOM here
+ * calling net_addrinfo_new for each entry.  Runs under lua_pcall so an OOM here
  * long-jumps back to do_getaddrinfo instead of leaking the C list.
  *
  * @param L Lua state.  On entry the stack is empty for this closure; on
@@ -611,7 +569,7 @@ static int build_addrinfo_list(lua_State *L)
 
     lua_createtable(L, 2, 0);
     for (ptr = list; ptr; ptr = ptr->ai_next) {
-        new_addrinfo(L, ptr);
+        net_addrinfo_new(L, ptr);
         lua_rawseti(L, -2, idx);
         idx++;
     }
@@ -712,17 +670,21 @@ static int inet6_lua(lua_State *L)
     size_t len                = 0;
     const char *addr          = lauxh_optlstring(L, 1, NULL, &len);
     uint16_t port             = lauxh_optuint16(L, 2, 0);
-    struct sockaddr_in6 saddr = {.sin6_family = AF_INET6,
-                                 .sin6_port   = htons(port),
-                                 .sin6_addr   = in6addr_any};
-    struct addrinfo ai        = {.ai_family    = AF_INET6,
-                                 .ai_socktype  = 0,
-                                 .ai_protocol  = 0,
-                                 .ai_flags     = 0,
-                                 .ai_addrlen   = sizeof(saddr),
-                                 .ai_addr      = (struct sockaddr *)&saddr,
-                                 .ai_canonname = NULL,
-                                 .ai_next      = NULL};
+    struct sockaddr_in6 saddr = {
+        .sin6_family = AF_INET6,
+        .sin6_port   = htons(port),
+        .sin6_addr   = in6addr_any,
+    };
+    struct addrinfo ai = {
+        .ai_family    = AF_INET6,
+        .ai_socktype  = 0,
+        .ai_protocol  = 0,
+        .ai_flags     = 0,
+        .ai_addrlen   = sizeof(saddr),
+        .ai_addr      = (struct sockaddr *)&saddr,
+        .ai_canonname = NULL,
+        .ai_next      = NULL,
+    };
 
     NET_SOCKET_CHECK_OPTIONS(L, 3, OPTS_ADDRINFO_SPECS, &ai);
 
@@ -746,7 +708,7 @@ static int inet6_lua(lua_State *L)
     }
 
     // create addrinfo
-    new_addrinfo(L, &ai);
+    net_addrinfo_new(L, &ai);
     return 1;
 }
 
@@ -768,17 +730,21 @@ static int inet_lua(lua_State *L)
     size_t len               = 0;
     const char *addr         = lauxh_optlstring(L, 1, NULL, &len);
     uint16_t port            = lauxh_optuint16(L, 2, 0);
-    struct sockaddr_in saddr = {.sin_family = AF_INET,
-                                .sin_port   = htons(port),
-                                .sin_addr   = {.s_addr = INADDR_ANY}};
-    struct addrinfo ai       = {.ai_family    = AF_INET,
-                                .ai_socktype  = 0,
-                                .ai_protocol  = 0,
-                                .ai_flags     = 0,
-                                .ai_addrlen   = sizeof(saddr),
-                                .ai_addr      = (struct sockaddr *)&saddr,
-                                .ai_canonname = NULL,
-                                .ai_next      = NULL};
+    struct sockaddr_in saddr = {
+        .sin_family = AF_INET,
+        .sin_port   = htons(port),
+        .sin_addr   = {.s_addr = INADDR_ANY},
+    };
+    struct addrinfo ai = {
+        .ai_family    = AF_INET,
+        .ai_socktype  = 0,
+        .ai_protocol  = 0,
+        .ai_flags     = 0,
+        .ai_addrlen   = sizeof(saddr),
+        .ai_addr      = (struct sockaddr *)&saddr,
+        .ai_canonname = NULL,
+        .ai_next      = NULL,
+    };
 
     NET_SOCKET_CHECK_OPTIONS(L, 3, OPTS_ADDRINFO_SPECS, &ai);
 
@@ -802,7 +768,7 @@ static int inet_lua(lua_State *L)
     }
 
     // create addrinfo
-    new_addrinfo(L, &ai);
+    net_addrinfo_new(L, &ai);
     return 1;
 }
 
@@ -846,7 +812,7 @@ static int unix_lua(lua_State *L)
     saddr.sun_path[len] = 0;
 
     // create addrinfo
-    new_addrinfo(L, &ai);
+    net_addrinfo_new(L, &ai);
     return 1;
 }
 

--- a/src/addrinfo.c
+++ b/src/addrinfo.c
@@ -42,84 +42,8 @@
 #include <sys/types.h>
 #include <sys/un.h>
 
-// ---------------------------------------------------------------------------
-// opts parsing
-// ---------------------------------------------------------------------------
-
-/**
- * @brief Description of a single opts key.  A specs array declares the
- * complete allowlist for an entry point; anything outside it is rejected.
- * The callback owns the type check, value mapping, and destination write.
- */
-typedef struct option_spec_st {
-    // Lua-visible key name in the opts table.
-    const char *name;
-    // Consume the value at stack index -1 and update `ctx` accordingly.
-    // Returns 0 on success; a Lua error is raised on any failure.
-    int (*callback)(lua_State *L, const char *name, void *ctx);
-} option_spec_t;
-
-/**
- * @brief Iterate the opts table at `idx` and dispatch each key to its spec's
- * callback.  A missing, nil, or none value at `idx` skips iteration.  A
- * non-table value, non-string keys, and keys not present in `specs` all
- * raise a Lua error.
- *
- * Because Lua table keys are unique, an already-matched spec cannot match
- * again; a fixed-size seen[] tracker skips those slots on subsequent keys.
- *
- * @param L Lua state.
- * @param idx Stack index of the opts value.
- * @param specs Array describing every accepted key.
- * @param nspecs Number of entries in `specs`.
- * @param ctx Caller-defined pointer passed through to every callback.
- */
-static void check_options(lua_State *L, int idx, const option_spec_t *specs,
-                          size_t nspecs, void *ctx)
-{
-#define MAX_SPECS 16
-
-    char seen[MAX_SPECS] = {0};
-    const char *key      = NULL;
-
-    // check that opts is a table and that the specs array is not too large
-    if (lua_isnoneornil(L, idx)) {
-        // no opts table, skip iteration
-        return;
-    } else if (lua_type(L, idx) != LUA_TTABLE) {
-        luaL_error(L, "opts must be table, got %s", luaL_typename(L, idx));
-    } else if (nspecs > MAX_SPECS) {
-        luaL_error(L, "opts spec array too large: %d > %d", (int)nspecs,
-                   (int)MAX_SPECS);
-    }
-
-#undef MAX_SPECS
-
-    lua_pushnil(L);
-CHECK_NEXT:
-    if (lua_next(L, idx) != 0) {
-        if (lua_type(L, -2) != LUA_TSTRING) {
-            luaL_error(L, "opts keys must be strings");
-        }
-        key = lua_tostring(L, -2);
-
-        // dispatch to the matching spec callback
-        for (size_t i = 0; i < nspecs; i++) {
-            if (!seen[i] && strcmp(key, specs[i].name) == 0) {
-                seen[i] = 1;
-                specs[i].callback(L, key, ctx);
-                lua_pop(L, 1);
-                goto CHECK_NEXT;
-            }
-        }
-        luaL_error(L, "invalid opts key: '%s'", key);
-    }
-}
-
-// Convenience macro that derives the spec count from a compile-time array.
-#define CHECK_OPTIONS(L, idx, specs, ctx)                                      \
-    check_options((L), (idx), (specs), sizeof(specs) / sizeof((specs)[0]),     \
-                  (ctx))
+// opts parsing framework (shared with src/socket.c)
+#include "optcheck.h"
 
 /**
  * @brief opts.family callback: map string to AF_* and store in
@@ -330,7 +254,7 @@ static int check_canonname(lua_State *L, const char *name, void *ctx)
 }
 
 // Shared spec arrays used by multiple entry points.
-static const option_spec_t OPTS_ADDRINFO_SPECS[] = {
+static const net_socket_option_spec_t OPTS_ADDRINFO_SPECS[] = {
     {"socktype",  check_socktype },
     {"protocol",  check_protocol },
     {"flags",     check_flags    },
@@ -742,7 +666,7 @@ static int do_getaddrinfo(lua_State *L, const char *host, const char *serv,
  */
 static int getaddrinfo_lua(lua_State *L)
 {
-    static const option_spec_t OPTS_GETADDRINFO_SPECS[] = {
+    static const net_socket_option_spec_t OPTS_GETADDRINFO_SPECS[] = {
         {"family",    check_family   },
         {"socktype",  check_socktype },
         {"protocol",  check_protocol },
@@ -766,7 +690,7 @@ static int getaddrinfo_lua(lua_State *L)
         lua_errno_eai_new(L, EAI_SERVICE, "getaddrinfo");
         return 2;
     }
-    CHECK_OPTIONS(L, 3, OPTS_GETADDRINFO_SPECS, &hints);
+    NET_SOCKET_CHECK_OPTIONS(L, 3, OPTS_GETADDRINFO_SPECS, &hints);
     return do_getaddrinfo(L, host, serv, &hints);
 }
 
@@ -800,7 +724,7 @@ static int inet6_lua(lua_State *L)
                                  .ai_canonname = NULL,
                                  .ai_next      = NULL};
 
-    CHECK_OPTIONS(L, 3, OPTS_ADDRINFO_SPECS, &ai);
+    NET_SOCKET_CHECK_OPTIONS(L, 3, OPTS_ADDRINFO_SPECS, &ai);
 
 #ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
     saddr.sin6_len = sizeof(saddr);
@@ -856,7 +780,7 @@ static int inet_lua(lua_State *L)
                                 .ai_canonname = NULL,
                                 .ai_next      = NULL};
 
-    CHECK_OPTIONS(L, 3, OPTS_ADDRINFO_SPECS, &ai);
+    NET_SOCKET_CHECK_OPTIONS(L, 3, OPTS_ADDRINFO_SPECS, &ai);
 
 #ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
     saddr.sin_len = sizeof(saddr);
@@ -909,7 +833,7 @@ static int unix_lua(lua_State *L)
                                 .ai_canonname = NULL,
                                 .ai_next      = NULL};
 
-    CHECK_OPTIONS(L, 2, OPTS_ADDRINFO_SPECS, &ai);
+    NET_SOCKET_CHECK_OPTIONS(L, 2, OPTS_ADDRINFO_SPECS, &ai);
 
     // length too large
     if (len >= UNIXPATH_MAX) {

--- a/src/addrinfo.c
+++ b/src/addrinfo.c
@@ -26,6 +26,7 @@
 #include "config.h"
 // project
 #include "addrinfo.h"
+#include "constants.h"
 // depend
 #include "lauxhlib.h"
 #include "lua_errno.h"
@@ -51,30 +52,16 @@
  */
 static int check_family(lua_State *L, const char *name, void *ctx)
 {
-    static const struct {
-        const char *name;
-        int value;
-    } MAP[] = {
-        {"unspec", AF_UNSPEC},
-        {"inet",   AF_INET  },
-        {"inet6",  AF_INET6 },
-        {"unix",   AF_UNIX  },
-        {NULL,     0        },
-    };
     struct addrinfo *hints = ctx;
     const char *s          = NULL;
-    int i                  = 0;
 
     if (lua_type(L, -1) != LUA_TSTRING) {
         return luaL_error(L, "opts.%s must be string, got %s", name,
                           luaL_typename(L, -1));
     }
     s = lua_tostring(L, -1);
-    for (i = 0; MAP[i].name; i++) {
-        if (strcmp(s, MAP[i].name) == 0) {
-            hints->ai_family = MAP[i].value;
-            return 0;
-        }
+    if (net_family_value(s, &hints->ai_family)) {
+        return 0;
     }
     return luaL_error(L, "invalid opts.%s value: '%s'", name, s);
 }
@@ -85,29 +72,16 @@ static int check_family(lua_State *L, const char *name, void *ctx)
  */
 static int check_socktype(lua_State *L, const char *name, void *ctx)
 {
-    static const struct {
-        const char *name;
-        int value;
-    } MAP[] = {
-        {"stream",    SOCK_STREAM   },
-        {"dgram",     SOCK_DGRAM    },
-        {"seqpacket", SOCK_SEQPACKET},
-        {NULL,        0             },
-    };
     struct addrinfo *hints = ctx;
     const char *s          = NULL;
-    int i                  = 0;
 
     if (lua_type(L, -1) != LUA_TSTRING) {
         return luaL_error(L, "opts.%s must be string, got %s", name,
                           luaL_typename(L, -1));
     }
     s = lua_tostring(L, -1);
-    for (i = 0; MAP[i].name; i++) {
-        if (strcmp(s, MAP[i].name) == 0) {
-            hints->ai_socktype = MAP[i].value;
-            return 0;
-        }
+    if (net_socktype_value(s, &hints->ai_socktype)) {
+        return 0;
     }
     return luaL_error(L, "invalid opts.%s value: '%s'", name, s);
 }
@@ -118,29 +92,16 @@ static int check_socktype(lua_State *L, const char *name, void *ctx)
  */
 static int check_protocol(lua_State *L, const char *name, void *ctx)
 {
-    static const struct {
-        const char *name;
-        int value;
-    } MAP[] = {
-        {"auto", 0          },
-        {"tcp",  IPPROTO_TCP},
-        {"udp",  IPPROTO_UDP},
-        {NULL,   0          },
-    };
     struct addrinfo *hints = ctx;
     const char *s          = NULL;
-    int i                  = 0;
 
     if (lua_type(L, -1) != LUA_TSTRING) {
         return luaL_error(L, "opts.%s must be string, got %s", name,
                           luaL_typename(L, -1));
     }
     s = lua_tostring(L, -1);
-    for (i = 0; MAP[i].name; i++) {
-        if (strcmp(s, MAP[i].name) == 0) {
-            hints->ai_protocol = MAP[i].value;
-            return 0;
-        }
+    if (net_protocol_value(s, &hints->ai_protocol)) {
+        return 0;
     }
     return luaL_error(L, "invalid opts.%s value: '%s'", name, s);
 }
@@ -151,39 +112,9 @@ static int check_protocol(lua_State *L, const char *name, void *ctx)
  */
 static int check_flags(lua_State *L, const char *name, void *ctx)
 {
-    static const struct {
-        const char *name;
-        int value;
-    } MAP[] = {
-        {"numerichost",              AI_NUMERICHOST             },
-        {"numericserv",              AI_NUMERICSERV             },
-        {"passive",                  AI_PASSIVE                 },
-        {"canonname",                AI_CANONNAME               },
-        {"addrconfig",               AI_ADDRCONFIG              },
-        {"v4mapped",                 AI_V4MAPPED                },
-        {"all",                      AI_ALL                     },
-#if defined(AI_IDN)
-        {"idn",                      AI_IDN                     },
-#endif
-#if defined(AI_CANONIDN)
-        {"canonidn",                 AI_CANONIDN                },
-#endif
-#if defined(AI_IDN_ALLOW_UNASSIGNED)
-        {"idn_allow_unassigned",     AI_IDN_ALLOW_UNASSIGNED    },
-#endif
-#if defined(AI_IDN_USE_STD3_ASCII_RULES)
-        {"idn_use_std3_ascii_rules", AI_IDN_USE_STD3_ASCII_RULES},
-#endif
-#if defined(AI_FQDN)
-        {"fqdn",                     AI_FQDN                    },
-#endif
-        {NULL,                       0                          },
-    };
     struct addrinfo *hints = ctx;
     lua_Integer len        = 0;
     lua_Integer i          = 0;
-    int j                  = 0;
-    int matched            = 0;
     const char *s          = NULL;
     int flags              = 0;
 
@@ -198,20 +129,14 @@ static int check_flags(lua_State *L, const char *name, void *ctx)
             return luaL_error(L, "opts.%s[%d] must be string, got %s", name,
                               (int)i, luaL_typename(L, -1));
         }
-        s       = lua_tostring(L, -1);
-        matched = 0;
-        for (j = 0; MAP[j].name; j++) {
-            if (strcmp(s, MAP[j].name) == 0) {
-                flags |= MAP[j].value;
-                matched = 1;
-                break;
-            }
-        }
+        int value = 0;
+        s         = lua_tostring(L, -1);
         lua_pop(L, 1);
-        if (!matched) {
+        if (!net_addrinfo_flag_value(s, &value)) {
             return luaL_error(L, "invalid opts.%s[%d] value: '%s'", name,
                               (int)i, s);
         }
+        flags |= value;
     }
     hints->ai_flags |= flags;
     return 0;
@@ -278,17 +203,6 @@ static const net_socket_option_spec_t OPTS_ADDRINFO_SPECS[] = {
  */
 static int getnameinfo_lua(lua_State *L)
 {
-    static const struct {
-        const char *name;
-        int value;
-    } NI_MAP[] = {
-        {"numerichost", NI_NUMERICHOST},
-        {"numericserv", NI_NUMERICSERV},
-        {"nofqdn",      NI_NOFQDN     },
-        {"namereqd",    NI_NAMEREQD   },
-        {"dgram",       NI_DGRAM      },
-        {NULL,          0             },
-    };
     net_addrinfo_t *info  = NULL;
     int flags             = 0;
     char host[NI_MAXHOST] = {0};
@@ -296,8 +210,6 @@ static int getnameinfo_lua(lua_State *L)
     int rc                = 0;
     int top               = 0;
     int i                 = 0;
-    int j                 = 0;
-    int matched           = 0;
     const char *s         = NULL;
 
     info = lauxh_checkudata(L, 1, NET_ADDRINFO_MT);
@@ -307,18 +219,12 @@ static int getnameinfo_lua(lua_State *L)
             luaL_error(L, "flag #%d must be string, got %s", i - 1,
                        luaL_typename(L, i));
         }
-        s       = lua_tostring(L, i);
-        matched = 0;
-        for (j = 0; NI_MAP[j].name; j++) {
-            if (strcmp(s, NI_MAP[j].name) == 0) {
-                flags |= NI_MAP[j].value;
-                matched = 1;
-                break;
-            }
-        }
-        if (!matched) {
+        int value = 0;
+        s         = lua_tostring(L, i);
+        if (!net_nameinfo_flag_value(s, &value)) {
             luaL_error(L, "invalid flag: '%s'", s);
         }
+        flags |= value;
     }
     rc = getnameinfo(info->ai.ai_addr, info->ai.ai_addrlen, host, NI_MAXHOST,
                      serv, NI_MAXSERV, flags);
@@ -436,7 +342,13 @@ static int canonname_lua(lua_State *L)
 static int protocol_lua(lua_State *L)
 {
     net_addrinfo_t *info = lauxh_checkudata(L, 1, NET_ADDRINFO_MT);
-    lua_pushinteger(L, info->ai.ai_protocol);
+    const char *name     = net_protocol_name(info->ai.ai_protocol);
+
+    if (!name) {
+        return luaL_error(L, "unsupported protocol value: %d",
+                          info->ai.ai_protocol);
+    }
+    lua_pushstring(L, name);
     return 1;
 }
 
@@ -448,7 +360,13 @@ static int protocol_lua(lua_State *L)
 static int socktype_lua(lua_State *L)
 {
     net_addrinfo_t *info = lauxh_checkudata(L, 1, NET_ADDRINFO_MT);
-    lua_pushinteger(L, info->ai.ai_socktype);
+    const char *name     = net_socktype_name(info->ai.ai_socktype);
+
+    if (!name) {
+        return luaL_error(L, "unsupported socket type value: %d",
+                          info->ai.ai_socktype);
+    }
+    lua_pushstring(L, name);
     return 1;
 }
 
@@ -460,7 +378,13 @@ static int socktype_lua(lua_State *L)
 static int family_lua(lua_State *L)
 {
     net_addrinfo_t *info = lauxh_checkudata(L, 1, NET_ADDRINFO_MT);
-    lua_pushinteger(L, info->ai.ai_family);
+    const char *name     = net_family_name(info->ai.ai_family);
+
+    if (!name) {
+        return luaL_error(L, "unsupported address family value: %d",
+                          info->ai.ai_family);
+    }
+    lua_pushstring(L, name);
     return 1;
 }
 

--- a/src/addrinfo.h
+++ b/src/addrinfo.h
@@ -26,7 +26,7 @@
 #define net_addrinfo_h
 
 // lua
-#include <lauxlib.h>
+#include "lauxhlib.h"
 
 // system
 #include <netdb.h>
@@ -44,5 +44,47 @@ typedef struct {
 } net_addrinfo_t;
 
 LUALIB_API int luaopen_net_addrinfo(lua_State *L);
+
+/**
+ * @brief Allocate a net.addrinfo userdata that owns copies of `src`'s
+ * sockaddr and canonical name.
+ *
+ * The sockaddr is copied into a Lua-managed sockaddr_storage userdata and
+ * kept alive with a registry reference so the returned addrinfo stays valid
+ * after the caller frees the source list.  The canonical name, if present,
+ * is copied into a Lua string that is likewise referenced from the userdata.
+ *
+ * @param L Lua state.
+ * @param src Source addrinfo whose contents are copied.
+ * @return Pointer to the newly pushed net_addrinfo_t userdata.
+ */
+static inline net_addrinfo_t *net_addrinfo_new(lua_State *L,
+                                               struct addrinfo *src)
+{
+    net_addrinfo_t *info = lua_newuserdata(L, sizeof(net_addrinfo_t));
+
+    info->ai_addr_ref      = LUA_NOREF;
+    info->ai_canonname_ref = LUA_NOREF;
+    lauxh_setmetatable(L, NET_ADDRINFO_MT);
+
+    // copy data
+    memcpy((void *)&info->ai, (void *)src, sizeof(struct addrinfo));
+    info->ai.ai_addr  = lua_newuserdata(L, sizeof(struct sockaddr_storage));
+    info->ai_addr_ref = lauxh_ref(L);
+
+    // copy sockaddr data
+    info->ai.ai_addrlen = src->ai_addrlen;
+    memcpy((void *)info->ai.ai_addr, (void *)src->ai_addr, src->ai_addrlen);
+
+    // copy canonname data
+    info->ai.ai_canonname = NULL;
+    if (src->ai_canonname) {
+        lua_pushstring(L, src->ai_canonname);
+        info->ai.ai_canonname  = (char *)lua_tostring(L, -1);
+        info->ai_canonname_ref = lauxh_ref(L);
+    }
+
+    return info;
+}
 
 #endif // net_addrinfo_h

--- a/src/constants.c
+++ b/src/constants.c
@@ -1,0 +1,154 @@
+/**
+ * Copyright (C) 2026 Masatoshi Fukunaga
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#define _GNU_SOURCE
+#include "constants.h"
+
+#include <netdb.h>
+#include <netinet/in.h>
+#include <stddef.h>
+#include <string.h>
+#include <sys/socket.h>
+
+typedef struct {
+    const char *name;
+    int value;
+} net_constant_t;
+
+static int name2value(const net_constant_t *map, const char *name, int *value)
+{
+    for (const net_constant_t *entry = map; entry->name; entry++) {
+        if (strcmp(entry->name, name) == 0) {
+            *value = entry->value;
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static const char *value2name(const net_constant_t *map, int value)
+{
+    for (const net_constant_t *entry = map; entry->name; entry++) {
+        if (entry->value == value) {
+            return entry->name;
+        }
+    }
+    return NULL;
+}
+
+static const net_constant_t FAMILY_MAP[] = {
+    {"unspec", AF_UNSPEC},
+    {"unix",   AF_UNIX  },
+    {"inet",   AF_INET  },
+    {"inet6",  AF_INET6 },
+    {NULL,      0        },
+};
+
+static const net_constant_t SOCKTYPE_MAP[] = {
+    {"unspec",    0             },
+    {"stream",    SOCK_STREAM   },
+    {"dgram",     SOCK_DGRAM    },
+    {"seqpacket", SOCK_SEQPACKET},
+    {NULL,         0             },
+};
+
+static const net_constant_t PROTOCOL_MAP[] = {
+    {"auto", 0          },
+    {"tcp",  IPPROTO_TCP},
+    {"udp",  IPPROTO_UDP},
+    {NULL,    0          },
+};
+
+static const net_constant_t ADDRINFO_FLAG_MAP[] = {
+    {"numerichost",              AI_NUMERICHOST             },
+    {"numericserv",              AI_NUMERICSERV             },
+    {"passive",                  AI_PASSIVE                 },
+    {"canonname",                AI_CANONNAME               },
+    {"addrconfig",               AI_ADDRCONFIG              },
+    {"v4mapped",                 AI_V4MAPPED                },
+    {"all",                      AI_ALL                     },
+#ifdef AI_IDN
+    {"idn",                      AI_IDN                     },
+#endif
+#ifdef AI_CANONIDN
+    {"canonidn",                 AI_CANONIDN                },
+#endif
+#ifdef AI_IDN_ALLOW_UNASSIGNED
+    {"idn_allow_unassigned",     AI_IDN_ALLOW_UNASSIGNED    },
+#endif
+#ifdef AI_IDN_USE_STD3_ASCII_RULES
+    {"idn_use_std3_ascii_rules", AI_IDN_USE_STD3_ASCII_RULES},
+#endif
+#ifdef AI_FQDN
+    {"fqdn",                     AI_FQDN                    },
+#endif
+    {NULL,                        0                          },
+};
+
+static const net_constant_t NAMEINFO_FLAG_MAP[] = {
+    {"numerichost", NI_NUMERICHOST},
+    {"numericserv", NI_NUMERICSERV},
+    {"nofqdn",      NI_NOFQDN     },
+    {"namereqd",    NI_NAMEREQD   },
+    {"dgram",       NI_DGRAM      },
+    {NULL,           0             },
+};
+
+const char *net_family_name(int value)
+{
+    return value2name(FAMILY_MAP, value);
+}
+
+int net_family_value(const char *name, int *value)
+{
+    return name2value(FAMILY_MAP, name, value);
+}
+
+const char *net_socktype_name(int value)
+{
+    return value2name(SOCKTYPE_MAP, value);
+}
+
+int net_socktype_value(const char *name, int *value)
+{
+    return name2value(SOCKTYPE_MAP, name, value);
+}
+
+const char *net_protocol_name(int value)
+{
+    return value2name(PROTOCOL_MAP, value);
+}
+
+int net_protocol_value(const char *name, int *value)
+{
+    return name2value(PROTOCOL_MAP, name, value);
+}
+
+int net_addrinfo_flag_value(const char *name, int *value)
+{
+    return name2value(ADDRINFO_FLAG_MAP, name, value);
+}
+
+int net_nameinfo_flag_value(const char *name, int *value)
+{
+    return name2value(NAMEINFO_FLAG_MAP, name, value);
+}

--- a/src/constants.h
+++ b/src/constants.h
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2026 Masatoshi Fukunaga
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef net_constants_h
+#define net_constants_h
+
+const char *net_family_name(int value);
+int net_family_value(const char *name, int *value);
+
+const char *net_socktype_name(int value);
+int net_socktype_value(const char *name, int *value);
+
+const char *net_protocol_name(int value);
+int net_protocol_value(const char *name, int *value);
+
+int net_addrinfo_flag_value(const char *name, int *value);
+int net_nameinfo_flag_value(const char *name, int *value);
+
+#endif

--- a/src/optcheck.h
+++ b/src/optcheck.h
@@ -1,0 +1,124 @@
+/**
+ *  Copyright (C) 2014-present Masatoshi Fukunaga
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to
+ *  deal in the Software without restriction, including without limitation the
+ *  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ *  sell copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ *  IN THE SOFTWARE.
+ */
+
+#ifndef net_optcheck_h
+#define net_optcheck_h
+
+#include <lauxlib.h>
+#include <string.h>
+
+/**
+ * @brief Callback for net_socket_option_spec_t that handles a single key/value
+ * pair in an opts table.
+ *
+ * Handles a single key/value pair in an opts table. key is the string key, and
+ * the value is at stack index -1. the value is consumed(popped) from the stack
+ * by the callback, but the key is not.
+ *
+ * @param L Lua state.
+ * @param name Key name.
+ * @param ctx Caller-defined pointer passed through to the callback.
+ * @return 0 on success; a Lua error is raised on any failure.
+ */
+typedef int (*net_socket_option_spec_cb)(lua_State *L, const char *name,
+                                         void *ctx);
+
+/**
+ * @brief Single opts table entry declaration.
+ *
+ * `net_socket_option_spec_t` binds a Lua string key to a C callback that
+ * consumes the corresponding value.  Modules describe their accepted opts as a
+ * compile-time array of these entries.
+ */
+typedef struct {
+    // Lua-visible key name in the opts table.
+    const char *name;
+    // Consume the value at stack index -1 and update `ctx` accordingly.
+    // Returns 0 on success; a Lua error is raised on any failure.
+    net_socket_option_spec_cb callback;
+} net_socket_option_spec_t;
+
+/**
+ * @brief Iterate the opts table at `idx` and dispatch each key to its spec's
+ * callback.  A missing, nil, or none value at `idx` skips iteration.  A
+ * non-table value, non-string keys raise a Lua error.  Unknown keys are
+ * ignored.  The `ctx` pointer is passed through to every callback.
+ *
+ * @param L Lua state.
+ * @param idx Stack index of the opts value.
+ * @param specs Array describing every accepted key.
+ * @param nspecs Number of entries in `specs`.
+ * @param ctx Caller-defined pointer passed through to every callback.
+ */
+static inline void
+net_socket_check_options(lua_State *L, int idx,
+                         const net_socket_option_spec_t specs[], size_t nspecs,
+                         void *ctx)
+{
+#define OPTCHECK_MAX_SPECS 16
+
+    char seen[OPTCHECK_MAX_SPECS] = {0};
+    const char *key               = NULL;
+    size_t i                      = 0;
+
+    // check that opts is a table and that the specs array is not too large
+    if (lua_isnoneornil(L, idx)) {
+        // no opts table, skip iteration
+        return;
+    } else if (lua_type(L, idx) != LUA_TTABLE) {
+        luaL_error(L, "opts must be table, got %s", luaL_typename(L, idx));
+    } else if (nspecs > OPTCHECK_MAX_SPECS) {
+        luaL_error(L, "opts spec array too large: %d > %d", (int)nspecs,
+                   (int)OPTCHECK_MAX_SPECS);
+    }
+
+#undef OPTCHECK_MAX_SPECS
+
+    lua_pushnil(L);
+CHECK_NEXT:
+    if (lua_next(L, idx) != 0) {
+        if (lua_type(L, -2) != LUA_TSTRING) {
+            luaL_error(L, "opts keys must be strings");
+        }
+        key = lua_tostring(L, -2);
+
+        // dispatch to the matching spec callback
+        for (i = 0; i < nspecs; i++) {
+            if (!seen[i] && strcmp(key, specs[i].name) == 0) {
+                seen[i] = 1;
+                specs[i].callback(L, key, ctx);
+                lua_pop(L, 1);
+                goto CHECK_NEXT;
+            }
+        }
+        // ignore unknown keys, but pop the value from the stack
+        lua_pop(L, 1);
+        goto CHECK_NEXT;
+    }
+}
+
+// Convenience macro that derives the spec count from a compile-time array.
+#define NET_SOCKET_CHECK_OPTIONS(L, idx, specs, ctx)                           \
+    net_socket_check_options((L), (idx), (specs),                              \
+                             sizeof(specs) / sizeof((specs)[0]), (ctx))
+
+#endif // net_optcheck_h

--- a/src/optcheck.h
+++ b/src/optcheck.h
@@ -74,7 +74,7 @@ net_socket_check_options(lua_State *L, int idx,
                          const net_socket_option_spec_t specs[], size_t nspecs,
                          void *ctx)
 {
-#define OPTCHECK_MAX_SPECS 16
+#define OPTCHECK_MAX_SPECS 32
 
     char seen[OPTCHECK_MAX_SPECS] = {0};
     const char *key               = NULL;

--- a/test/addrinfo_test.lua
+++ b/test/addrinfo_test.lua
@@ -27,7 +27,9 @@ end
 -- low-level: addrinfo.inet
 --
 function testcase.inet()
-    -- test that create IPv4 addrinfo with default options
+    -- Create an IPv4 addrinfo with the default options: socktype = 0,
+    -- protocol = 0, no flags, no canonname.  addrinfo:family/addr/port/
+    -- socktype/protocol/canonname all return the expected defaults.
     local ai = assert(addrinfo.inet('127.0.0.1', 8080))
     assert.match(tostring(ai), '^net.addrinfo: ', false)
     assert.equal(ai:family(), net.AF_INET)
@@ -36,50 +38,65 @@ function testcase.inet()
     assert.equal(ai:socktype(), 0)
     assert.equal(ai:protocol(), 0)
     assert.is_nil(ai:canonname())
+end
 
-    -- test that address and port are optional (wildcard)
-    ai = assert(addrinfo.inet())
+function testcase.inet_wildcard()
+    -- addrinfo.inet() with no arguments returns the IPv4 wildcard (0.0.0.0:0).
+    local ai = assert(addrinfo.inet())
     assert.equal(ai:addr(), '0.0.0.0')
     assert.equal(ai:port(), 0)
+end
 
-    -- test that opts.socktype and opts.protocol are applied
-    ai = assert(addrinfo.inet('127.0.0.1', 80, {
+function testcase.inet_opts_socktype_protocol()
+    -- opts.socktype and opts.protocol are applied to the resulting
+    -- addrinfo (both the stream/tcp and dgram/udp forms).
+    local ai = assert(addrinfo.inet('127.0.0.1', 80, {
         socktype = 'stream',
         protocol = 'tcp',
     }))
     assert.equal(ai:socktype(), net.SOCK_STREAM)
     assert.equal(ai:protocol(), net.IPPROTO_TCP)
 
-    -- test that opts.socktype = 'dgram' + protocol = 'udp' works
     ai = assert(addrinfo.inet('127.0.0.1', 53, {
         socktype = 'dgram',
         protocol = 'udp',
     }))
     assert.equal(ai:socktype(), net.SOCK_DGRAM)
     assert.equal(ai:protocol(), net.IPPROTO_UDP)
+end
 
-    -- test that invalid IPv4 address returns error
-    local _, err = addrinfo.inet('not.an.ip.address', 0)
+function testcase.inet_invalid_address()
+    -- An address that inet_pton() cannot parse surfaces an EAI-style
+    -- error object.
+    local ai, err = addrinfo.inet('not.an.ip.address', 0)
+    assert.is_nil(ai)
     assert(err, 'expected error for invalid IPv4 address')
+end
 
-    -- test that opts.socktype must be a known enum
-    err = assert.throws(function()
+function testcase.inet_invalid_socktype()
+    -- opts.socktype must be one of the recognized symbolic names.
+    local err = assert.throws(function()
         addrinfo.inet('127.0.0.1', 0, {
             socktype = 'bogus',
         })
     end)
     assert.match(err, 'socktype', false)
+end
 
-    -- test that opts.protocol must be a known enum
-    err = assert.throws(function()
+function testcase.inet_invalid_protocol()
+    -- opts.protocol must be one of the recognized symbolic names.
+    local err = assert.throws(function()
         addrinfo.inet('127.0.0.1', 0, {
             protocol = 'bogus',
         })
     end)
     assert.match(err, 'protocol', false)
+end
 
-    -- test that opts.flags must be an array of known strings
-    err = assert.throws(function()
+function testcase.inet_invalid_flags()
+    -- opts.flags is an array of strings where every element must be a
+    -- recognized AI_* flag name.
+    local err = assert.throws(function()
         addrinfo.inet('127.0.0.1', 0, {
             flags = {
                 'passive',
@@ -88,15 +105,20 @@ function testcase.inet()
         })
     end)
     assert.match(err, 'flags', false)
+end
 
-    -- test that unknown opts keys are silently ignored
-    ai = assert(addrinfo.inet('127.0.0.1', 0, {
+function testcase.inet_ignores_unknown_opts()
+    -- Unknown opts keys are silently ignored so that callers can pass a
+    -- superset of options without a check-per-key roundtrip.
+    local ai = assert(addrinfo.inet('127.0.0.1', 0, {
         typo_option = true,
     }))
     assert.equal(ai:family(), net.AF_INET)
+end
 
-    -- test that opts must be a table
-    err = assert.throws(function()
+function testcase.inet_opts_must_be_table()
+    -- opts, if provided, must be a Lua table.
+    local err = assert.throws(function()
         addrinfo.inet('127.0.0.1', 0, 'not-a-table')
     end)
     assert.match(err, 'opts', false)
@@ -106,27 +128,36 @@ end
 -- low-level: addrinfo.inet6
 --
 function testcase.inet6()
-    -- test that create IPv6 addrinfo with default options
+    -- Create an IPv6 addrinfo with the default options.
     local ai = assert(addrinfo.inet6('::1', 8080))
     assert.equal(ai:family(), net.AF_INET6)
     assert.equal(ai:addr(), '::1')
     assert.equal(ai:port(), 8080)
+end
 
-    -- test that address and port are optional (wildcard)
-    ai = assert(addrinfo.inet6())
+function testcase.inet6_wildcard()
+    -- addrinfo.inet6() with no arguments returns the IPv6 wildcard (::0).
+    local ai = assert(addrinfo.inet6())
     assert.equal(ai:addr(), '::')
     assert.equal(ai:port(), 0)
+end
 
-    -- test that opts.socktype = 'stream' + protocol = 'tcp' works
-    ai = assert(addrinfo.inet6('::1', 80, {
+function testcase.inet6_opts_socktype_protocol()
+    -- opts.socktype and opts.protocol are applied to the resulting IPv6
+    -- addrinfo.
+    local ai = assert(addrinfo.inet6('::1', 80, {
         socktype = 'stream',
         protocol = 'tcp',
     }))
     assert.equal(ai:socktype(), net.SOCK_STREAM)
     assert.equal(ai:protocol(), net.IPPROTO_TCP)
+end
 
-    -- test that invalid IPv6 address returns error
-    local _, err = addrinfo.inet6('not.an.ip6', 0)
+function testcase.inet6_invalid_address()
+    -- An address that inet_pton() cannot parse surfaces an EAI-style
+    -- error object.
+    local ai, err = addrinfo.inet6('not.an.ip6', 0)
+    assert.is_nil(ai)
     assert(err, 'expected error for invalid IPv6 address')
 end
 
@@ -134,29 +165,38 @@ end
 -- low-level: addrinfo.unix
 --
 function testcase.unix()
+    -- Create an AF_UNIX addrinfo from a pathname.  addrinfo:family/addr
+    -- reflect AF_UNIX and the given path; port is nil because unix sockets
+    -- do not have a port.  socktype and protocol default to 0.
     local path = tmpsock()
-
-    -- test that create AF_UNIX addrinfo from a pathname
     local ai = assert(addrinfo.unix(path))
     assert.equal(ai:family(), net.AF_UNIX)
     assert.equal(ai:addr(), path)
     assert.is_nil(ai:port())
     assert.equal(ai:socktype(), 0)
     assert.equal(ai:protocol(), 0)
+end
 
-    -- test that opts.socktype = 'stream' works
-    ai = assert(addrinfo.unix(path, {
+function testcase.unix_opts_socktype()
+    -- opts.socktype is applied to the resulting AF_UNIX addrinfo.
+    local path = tmpsock()
+    local ai = assert(addrinfo.unix(path, {
         socktype = 'stream',
     }))
     assert.equal(ai:socktype(), net.SOCK_STREAM)
+end
 
-    -- test that a pathname that exceeds sun_path length returns ENAMETOOLONG
+function testcase.unix_pathname_too_long()
+    -- A pathname that exceeds sun_path length surfaces ENAMETOOLONG.
     local long = string.rep('x', UNIX_PATH_MAX + 1)
-    local _, err = addrinfo.unix(long)
+    local ai, err = addrinfo.unix(long)
+    assert.is_nil(ai)
     assert.equal(err.type, errno.ENAMETOOLONG)
+end
 
-    -- test that pathname is required
-    err = assert.throws(function()
+function testcase.unix_pathname_required()
+    -- The pathname argument is required; omitting it raises a Lua error.
+    local err = assert.throws(function()
         addrinfo.unix()
     end)
     assert.match(err, 'string expected', false)
@@ -166,7 +206,9 @@ end
 -- getaddrinfo
 --
 function testcase.getaddrinfo()
-    -- test that resolves 127.0.0.1 to an IPv4 addrinfo list
+    -- Resolve 127.0.0.1 (a literal IPv4) into a list of matching
+    -- addrinfo entries.  All entries should carry the family / socktype /
+    -- protocol we requested through opts.
     local addrs = assert(addrinfo.getaddrinfo('127.0.0.1', 0, {
         family = 'inet',
         socktype = 'stream',
@@ -178,9 +220,12 @@ function testcase.getaddrinfo()
         assert.equal(ai:socktype(), net.SOCK_STREAM)
         assert.equal(ai:protocol(), net.IPPROTO_TCP)
     end
+end
 
-    -- test that AI_PASSIVE flag returns wildcard when host is nil
-    addrs = assert(addrinfo.getaddrinfo(nil, 0, {
+function testcase.getaddrinfo_passive_wildcard()
+    -- opts.flags = {'passive'} + host = nil produces the wildcard
+    -- addrinfo (0.0.0.0 for IPv4).
+    local addrs = assert(addrinfo.getaddrinfo(nil, 0, {
         family = 'inet',
         socktype = 'stream',
         flags = {
@@ -188,37 +233,49 @@ function testcase.getaddrinfo()
         },
     }))
     assert.equal(addrs[1]:addr(), '0.0.0.0')
+end
 
-    -- test that unresolvable hostname returns EAI_NONAME
-    local _, err = addrinfo.getaddrinfo('invalid.host.example.invalid', 0)
+function testcase.getaddrinfo_unresolvable_host()
+    -- An unresolvable hostname surfaces EAI_NONAME.
+    local ai, err = addrinfo.getaddrinfo('invalid.host.example.invalid', 0)
+    assert.is_nil(ai)
     assert(err)
     assert.equal(err.type, errno_eai.EAI_NONAME)
+end
 
-    -- test that non-integer port returns EAI_SERVICE
-    _, err = addrinfo.getaddrinfo('127.0.0.1', 'invalid-service')
+function testcase.getaddrinfo_invalid_service()
+    -- A non-numeric port that is not a known service name surfaces
+    -- EAI_SERVICE (or EAI_NONAME on some platforms).
+    local ai, err = addrinfo.getaddrinfo('127.0.0.1', 'invalid-service')
+    assert.is_nil(ai)
     assert(err)
     assert(err.type == errno_eai.EAI_SERVICE or err.type == errno_eai.EAI_NONAME)
+end
 
-    -- test that unknown enum value in opts.family throws
-    err = assert.throws(function()
+function testcase.getaddrinfo_invalid_family()
+    -- opts.family must be one of the recognized symbolic names.
+    local err = assert.throws(function()
         addrinfo.getaddrinfo('127.0.0.1', 0, {
             family = 'bogus',
         })
     end)
     assert.match(err, 'family', false)
+end
 
-    -- test that unknown opts keys are silently ignored
-    local ok = assert(addrinfo.getaddrinfo('127.0.0.1', 0, {
+function testcase.getaddrinfo_ignores_unknown_opts()
+    -- Unknown opts keys are silently ignored.
+    local addrs = assert(addrinfo.getaddrinfo('127.0.0.1', 0, {
         typo = 1,
     }))
-    assert.greater(#ok, 0)
+    assert.greater(#addrs, 0)
 end
 
 --
 -- inet with socktype/protocol/passive/canonname opts
 --
 function testcase.inet_typed_convenience()
-    -- test that opts.socktype + opts.protocol produce a TCP stream addrinfo
+    -- opts.socktype + opts.protocol produce a fully-typed TCP stream
+    -- addrinfo (family/addr/port/socktype/protocol all set).
     local ai = assert(addrinfo.inet('127.0.0.1', 8080, {
         socktype = 'stream',
         protocol = 'tcp',
@@ -228,25 +285,33 @@ function testcase.inet_typed_convenience()
     assert.equal(ai:protocol(), net.IPPROTO_TCP)
     assert.equal(ai:addr(), '127.0.0.1')
     assert.equal(ai:port(), 8080)
+end
 
-    -- test that opts.passive OR's AI_PASSIVE into the wildcard addrinfo
-    ai = assert(addrinfo.inet(nil, 0, {
+function testcase.inet_passive_wildcard()
+    -- opts.passive = true ORs AI_PASSIVE into the addrinfo flags; combined
+    -- with host = nil this produces the IPv4 wildcard.
+    local ai = assert(addrinfo.inet(nil, 0, {
         socktype = 'stream',
         protocol = 'tcp',
         passive = true,
     }))
     assert.equal(ai:addr(), '0.0.0.0')
+end
 
-    -- test that opts.passive must be boolean
+function testcase.inet_passive_must_be_boolean()
+    -- opts.passive must be a boolean; non-boolean values raise a Lua error.
     local err = assert.throws(function()
         addrinfo.inet('127.0.0.1', 0, {
             passive = 1,
         })
     end)
     assert.match(err, 'passive', false)
+end
 
-    -- test that opts.socktype = 'dgram' + protocol = 'udp' works
-    ai = assert(addrinfo.inet('127.0.0.1', 53, {
+function testcase.inet_typed_convenience_dgram()
+    -- opts.socktype = 'dgram' + protocol = 'udp' produces a UDP dgram
+    -- addrinfo.
+    local ai = assert(addrinfo.inet('127.0.0.1', 53, {
         socktype = 'dgram',
         protocol = 'udp',
     }))
@@ -254,11 +319,8 @@ function testcase.inet_typed_convenience()
     assert.equal(ai:protocol(), net.IPPROTO_UDP)
 end
 
---
--- inet6 with socktype/protocol opts
---
 function testcase.inet6_typed_convenience()
-    -- test that opts produce a TCP IPv6 stream addrinfo
+    -- opts produce a fully-typed TCP IPv6 stream addrinfo.
     local ai = assert(addrinfo.inet6('::1', 8080, {
         socktype = 'stream',
         protocol = 'tcp',
@@ -268,9 +330,11 @@ function testcase.inet6_typed_convenience()
     assert.equal(ai:protocol(), net.IPPROTO_TCP)
     assert.equal(ai:addr(), '::1')
     assert.equal(ai:port(), 8080)
+end
 
-    -- test that opts.socktype = 'dgram' + protocol = 'udp' works
-    ai = assert(addrinfo.inet6('::1', 53, {
+function testcase.inet6_typed_convenience_dgram()
+    -- opts.socktype = 'dgram' + protocol = 'udp' works on IPv6 too.
+    local ai = assert(addrinfo.inet6('::1', 53, {
         socktype = 'dgram',
         protocol = 'udp',
     }))
@@ -282,51 +346,70 @@ end
 -- unix with socktype opts
 --
 function testcase.unix_typed_convenience()
+    -- opts.socktype = 'stream' produces a fully-typed AF_UNIX / SOCK_STREAM
+    -- addrinfo.
     local path = tmpsock()
-
-    -- test that opts.socktype = 'stream' works
     local ai = assert(addrinfo.unix(path, {
         socktype = 'stream',
     }))
     assert.equal(ai:family(), net.AF_UNIX)
     assert.equal(ai:socktype(), net.SOCK_STREAM)
     assert.equal(ai:addr(), path)
+end
 
-    -- test that opts.socktype = 'dgram' works
-    ai = assert(addrinfo.unix(path, {
+function testcase.unix_typed_convenience_dgram()
+    -- opts.socktype = 'dgram' produces an AF_UNIX / SOCK_DGRAM addrinfo.
+    local path = tmpsock()
+    local ai = assert(addrinfo.unix(path, {
         socktype = 'dgram',
     }))
     assert.equal(ai:socktype(), net.SOCK_DGRAM)
+end
 
-    -- test that ENAMETOOLONG is returned for too long pathname
-    local _, err = addrinfo.unix(string.rep('x', UNIX_PATH_MAX + 1), {
+function testcase.unix_typed_convenience_pathname_too_long()
+    -- A pathname that exceeds sun_path length surfaces ENAMETOOLONG even
+    -- when opts.socktype is provided.
+    local ai, err = addrinfo.unix(string.rep('x', UNIX_PATH_MAX + 1), {
         socktype = 'stream',
     })
+    assert.is_nil(ai)
     assert.equal(err.type, errno.ENAMETOOLONG)
 end
 
---
--- getaddrinfo with passive/canonname boolean shortcuts
---
-function testcase.getaddrinfo_boolean_shortcuts()
-    -- test that opts.passive is honored as an AI_PASSIVE shortcut
+function testcase.getaddrinfo_boolean_shortcuts_passive()
+    -- opts.passive is honored as an AI_PASSIVE shortcut on getaddrinfo().
     local addrs = assert(addrinfo.getaddrinfo(nil, 0, {
         family = 'inet',
         socktype = 'stream',
         passive = true,
     }))
     assert.greater(#addrs, 0)
+end
 
-    -- test that opts.passive must be boolean
+function testcase.getaddrinfo_boolean_shortcuts_canonname()
+    -- opts.canonname is honored as an AI_CANONNAME shortcut; this drives
+    -- check_canonname's `hints->ai_flags |= AI_CANONNAME` branch.
+    local addrs = assert(addrinfo.getaddrinfo('localhost', 0, {
+        family = 'inet',
+        socktype = 'stream',
+        canonname = true,
+    }))
+    assert.greater(#addrs, 0)
+end
+
+function testcase.getaddrinfo_passive_must_be_boolean()
+    -- opts.passive must be a boolean.
     local err = assert.throws(function()
         addrinfo.getaddrinfo(nil, 0, {
             passive = 'yes',
         })
     end)
     assert.match(err, 'passive', false)
+end
 
-    -- test that opts.canonname must be boolean
-    err = assert.throws(function()
+function testcase.getaddrinfo_canonname_must_be_boolean()
+    -- opts.canonname must be a boolean.
+    local err = assert.throws(function()
         addrinfo.getaddrinfo('127.0.0.1', 0, {
             canonname = 1,
         })
@@ -334,31 +417,63 @@ function testcase.getaddrinfo_boolean_shortcuts()
     assert.match(err, 'canonname', false)
 end
 
---
--- methods
---
-function testcase.methods()
+function testcase.family()
+    -- family() returns the AF_* constant of the addrinfo.
     local ai = assert(addrinfo.inet('127.0.0.1', 8080, {
         socktype = 'stream',
         protocol = 'tcp',
     }))
-
-    -- test that family() returns AF_INET
     assert.equal(ai:family(), net.AF_INET)
-    -- test that socktype() returns SOCK_STREAM
-    assert.equal(ai:socktype(), net.SOCK_STREAM)
-    -- test that protocol() returns IPPROTO_TCP
-    assert.equal(ai:protocol(), net.IPPROTO_TCP)
-    -- test that addr() returns the string form of the address
-    assert.equal(ai:addr(), '127.0.0.1')
-    -- test that port() returns the integer port
-    assert.equal(ai:port(), 8080)
-    -- test that canonname() is nil when not requested
-    assert.is_nil(ai:canonname())
-    -- test that tostring embeds the metatable name
-    assert.match(tostring(ai), '^net.addrinfo: ', false)
+end
 
-    -- test that canonname() is populated when requested
+function testcase.socktype()
+    -- socktype() returns the SOCK_* constant configured via opts.socktype.
+    local ai = assert(addrinfo.inet('127.0.0.1', 8080, {
+        socktype = 'stream',
+        protocol = 'tcp',
+    }))
+    assert.equal(ai:socktype(), net.SOCK_STREAM)
+end
+
+function testcase.protocol()
+    -- protocol() returns the IPPROTO_* constant configured via
+    -- opts.protocol.
+    local ai = assert(addrinfo.inet('127.0.0.1', 8080, {
+        socktype = 'stream',
+        protocol = 'tcp',
+    }))
+    assert.equal(ai:protocol(), net.IPPROTO_TCP)
+end
+
+function testcase.addr()
+    -- addr() returns the string form of the address (IPv4 dotted-quad,
+    -- IPv6 hex, or unix path).
+    local ai = assert(addrinfo.inet('127.0.0.1', 8080, {
+        socktype = 'stream',
+        protocol = 'tcp',
+    }))
+    assert.equal(ai:addr(), '127.0.0.1')
+end
+
+function testcase.port()
+    -- port() returns the integer port number stored in the sockaddr.
+    local ai = assert(addrinfo.inet('127.0.0.1', 8080, {
+        socktype = 'stream',
+        protocol = 'tcp',
+    }))
+    assert.equal(ai:port(), 8080)
+end
+
+function testcase.canonname()
+    -- canonname() returns nil when AI_CANONNAME was not requested; it
+    -- returns the canonical hostname string when 'canonname' is included
+    -- in opts.flags via getaddrinfo().
+    local ai = assert(addrinfo.inet('127.0.0.1', 8080, {
+        socktype = 'stream',
+        protocol = 'tcp',
+    }))
+    assert.is_nil(ai:canonname())
+
     local addrs = assert(addrinfo.getaddrinfo('localhost', 0, {
         family = 'inet',
         socktype = 'stream',
@@ -369,26 +484,50 @@ function testcase.methods()
     assert.is_string(addrs[1]:canonname())
 end
 
+function testcase.tostring()
+    -- tostring(ai) returns a string identifying the userdata's metatable
+    -- and pointer, matching Lua's standard __tostring convention.
+    local ai = assert(addrinfo.inet('127.0.0.1', 8080, {
+        socktype = 'stream',
+        protocol = 'tcp',
+    }))
+    assert.match(tostring(ai), '^net.addrinfo: ', false)
+end
+
 --
 -- ai:getnameinfo
 --
 function testcase.getnameinfo()
+    -- ai:getnameinfo() with no flags reverses the addrinfo into a
+    -- {host, service} table via getnameinfo(3).
     local ai = assert(addrinfo.inet('127.0.0.1', 22, {
         socktype = 'stream',
         protocol = 'tcp',
     }))
-
-    -- test that returns {host, service} table without flags
     local info = assert(ai:getnameinfo())
     assert.is_string(info.host)
     assert.is_string(info.service)
+end
 
-    -- test that numerichost / numericserv flags return literal values
-    info = assert(ai:getnameinfo('numerichost', 'numericserv'))
+function testcase.getnameinfo_numeric_flags()
+    -- 'numerichost' + 'numericserv' bypass reverse DNS / service lookup
+    -- and return the literal address and port.
+    local ai = assert(addrinfo.inet('127.0.0.1', 22, {
+        socktype = 'stream',
+        protocol = 'tcp',
+    }))
+    local info = assert(ai:getnameinfo('numerichost', 'numericserv'))
     assert.equal(info.host, '127.0.0.1')
     assert.equal(info.service, '22')
+end
 
-    -- test that invalid flag string is rejected
+function testcase.getnameinfo_invalid_flag_string()
+    -- An unknown flag name surfaces a Lua error identifying the offending
+    -- string.
+    local ai = assert(addrinfo.inet('127.0.0.1', 22, {
+        socktype = 'stream',
+        protocol = 'tcp',
+    }))
     local err = assert.throws(function()
         ai:getnameinfo('bogus')
     end)
@@ -399,15 +538,14 @@ end
 -- unix family does not expose port
 --
 function testcase.unix_port_is_nil()
+    -- AF_UNIX addrinfo values do not carry a port; the port() method
+    -- returns nil rather than an integer.
     local ai = assert(addrinfo.unix(tmpsock(), {
         socktype = 'stream',
     }))
     assert.is_nil(ai:port())
 end
 
---
--- flags array and boolean shortcuts must combine, not clobber
---
 function testcase.flags_combine_with_booleans()
     -- passive shortcut + flags array set at the same time; independent of
     -- Lua's undefined key enumeration order the final ai_flags must include
@@ -434,25 +572,29 @@ end
 --
 -- opts validation edge cases
 --
-function testcase.opts_type_errors()
-    -- test that opts.family must be a string
+function testcase.opts_family_must_be_string()
+    -- opts.family must be a string; a non-string value raises a Lua error.
     local err = assert.throws(function()
         addrinfo.getaddrinfo('127.0.0.1', 0, {
             family = 4,
         })
     end)
     assert.match(err, 'family', false)
+end
 
-    -- test that opts.flags must be a table
-    err = assert.throws(function()
+function testcase.opts_flags_must_be_table()
+    -- opts.flags must be a table (an array of AI_* flag names).
+    local err = assert.throws(function()
         addrinfo.inet('127.0.0.1', 0, {
             flags = 'passive',
         })
     end)
     assert.match(err, 'flags', false)
+end
 
-    -- test that opts.flags element must be a string
-    err = assert.throws(function()
+function testcase.opts_flags_element_must_be_string()
+    -- Each entry inside opts.flags must be a string.
+    local err = assert.throws(function()
         addrinfo.inet('127.0.0.1', 0, {
             flags = {
                 1,
@@ -460,9 +602,12 @@ function testcase.opts_type_errors()
         })
     end)
     assert.match(err, 'flags', false)
+end
 
-    -- test that opts key must be a string (numeric-index keys rejected)
-    err = assert.throws(function()
+function testcase.opts_numeric_index_keys_rejected()
+    -- opts keys must all be strings; array-style (numeric-index) entries
+    -- are rejected.
+    local err = assert.throws(function()
         addrinfo.inet('127.0.0.1', 0, {
             'passive',
         })
@@ -470,34 +615,166 @@ function testcase.opts_type_errors()
     assert.match(err, 'opts', false)
 end
 
---
--- port variants
---
-function testcase.port_variants()
-    -- test that string port is accepted
+function testcase.opts_socktype_invalid_string()
+    -- An unrecognized opts.socktype string surfaces a diagnostic Lua
+    -- error via check_socktype.
+    local err = assert.throws(function()
+        addrinfo.getaddrinfo('127.0.0.1', 0, {
+            socktype = 'invalid',
+        })
+    end)
+    assert.match(err, 'socktype', false)
+    assert.match(err, 'invalid', false)
+end
+
+function testcase.opts_protocol_invalid_string()
+    -- An unrecognized opts.protocol string surfaces a diagnostic Lua
+    -- error via check_protocol.
+    local err = assert.throws(function()
+        addrinfo.getaddrinfo('127.0.0.1', 0, {
+            protocol = 'invalid',
+        })
+    end)
+    assert.match(err, 'protocol', false)
+    assert.match(err, 'invalid', false)
+end
+
+function testcase.opts_socktype_must_be_string()
+    -- opts.socktype must be a string.
+    local err = assert.throws(function()
+        addrinfo.getaddrinfo('127.0.0.1', 0, {
+            socktype = 123,
+        })
+    end)
+    assert.match(err, 'socktype', false)
+    assert.match(err, 'string', false)
+end
+
+function testcase.opts_protocol_must_be_string()
+    -- opts.protocol must be a string.
+    local err = assert.throws(function()
+        addrinfo.getaddrinfo('127.0.0.1', 0, {
+            protocol = 123,
+        })
+    end)
+    assert.match(err, 'protocol', false)
+    assert.match(err, 'string', false)
+end
+
+function testcase.opts_passive_must_be_boolean()
+    -- opts.passive must be a boolean.
+    local err = assert.throws(function()
+        addrinfo.getaddrinfo('127.0.0.1', 0, {
+            passive = 'notbool',
+        })
+    end)
+    assert.match(err, 'passive', false)
+end
+
+function testcase.opts_canonname_must_be_boolean()
+    -- opts.canonname must be a boolean.
+    local err = assert.throws(function()
+        addrinfo.getaddrinfo('127.0.0.1', 0, {
+            canonname = 123,
+        })
+    end)
+    assert.match(err, 'canonname', false)
+end
+
+function testcase.getnameinfo_flag_must_be_string()
+    -- ai:getnameinfo() flag arguments must be strings.
+    local ai = assert(addrinfo.inet('127.0.0.1', 0, {
+        socktype = 'stream',
+    }))
+    local err = assert.throws(function()
+        ai:getnameinfo(123)
+    end)
+    assert.match(err, 'must be string', false)
+end
+
+function testcase.getnameinfo_unknown_flag()
+    -- ai:getnameinfo() rejects flag names outside the recognized set.
+    local ai = assert(addrinfo.inet('127.0.0.1', 0, {
+        socktype = 'stream',
+    }))
+    local err = assert.throws(function()
+        ai:getnameinfo('unknown_flag')
+    end)
+    assert.match(err, 'invalid flag', false)
+end
+
+function testcase.getnameinfo_surfaces_resolver_error()
+    -- ai:getnameinfo('namereqd') on an IP with no reverse DNS returns
+    -- (nil, err_eai) — this drives the rc != 0 branch of getnameinfo_lua.
+    local ai = assert(addrinfo.inet('192.0.2.1', 80, {
+        socktype = 'stream',
+    }))
+    local r, err = ai:getnameinfo('namereqd')
+    assert.is_nil(r)
+    assert(err)
+end
+
+function testcase.port_variants_string()
+    -- getaddrinfo() accepts a string port (either numeric or a service
+    -- name).  A numeric string is parsed as an integer port.
     local addrs = assert(addrinfo.getaddrinfo('127.0.0.1', '80', {
         family = 'inet',
         socktype = 'stream',
     }))
     assert.equal(addrs[1]:port(), 80)
+end
 
-    -- test that negative port is rejected
-    local _, err = addrinfo.getaddrinfo('127.0.0.1', -1)
+function testcase.port_variants_negative()
+    -- Negative port numbers are outside the uint16 range and surface
+    -- EAI_SERVICE.
+    local ai, err = addrinfo.getaddrinfo('127.0.0.1', -1)
+    assert.is_nil(ai)
     assert(err)
     assert.equal(err.type, errno_eai.EAI_SERVICE)
+end
 
-    -- test that port exceeding UINT16_MAX is rejected
-    _, err = addrinfo.getaddrinfo('127.0.0.1', 65536)
+function testcase.port_variants_overflow()
+    -- Port numbers > UINT16_MAX are outside the valid range.
+    local ai, err = addrinfo.getaddrinfo('127.0.0.1', 65536)
+    assert.is_nil(ai)
     assert(err)
     assert.equal(err.type, errno_eai.EAI_SERVICE)
+end
 
-    -- test that non-integer port number is rejected
-    _, err = addrinfo.getaddrinfo('127.0.0.1', 1.5)
+function testcase.port_variants_non_integer()
+    -- Non-integer numeric ports (e.g. 1.5) are rejected because the
+    -- underlying sockaddr port is a uint16.
+    local ai, err = addrinfo.getaddrinfo('127.0.0.1', 1.5)
+    assert.is_nil(ai)
     assert(err)
     assert.equal(err.type, errno_eai.EAI_SERVICE)
+end
 
-    -- test that boolean port is rejected
-    _, err = addrinfo.getaddrinfo('127.0.0.1', true)
+function testcase.port_variants_boolean()
+    -- Non-numeric / non-string port arguments (e.g. a boolean) are
+    -- rejected by get_service()'s type dispatch.
+    local ai, err = addrinfo.getaddrinfo('127.0.0.1', true)
+    assert.is_nil(ai)
     assert(err)
     assert.equal(err.type, errno_eai.EAI_SERVICE)
+end
+
+function testcase.port_variants_nil()
+    -- A nil port is accepted (LUA_TNIL branch of get_service); the
+    -- resulting addrinfo carries port = 0.
+    local addrs = assert(addrinfo.getaddrinfo('127.0.0.1', nil, {
+        family = 'inet',
+        socktype = 'stream',
+    }))
+    assert.greater(#addrs, 0)
+end
+
+function testcase.port_variants_empty_string()
+    -- An empty-string port is accepted via the LUA_TSTRING slen==0 branch
+    -- of get_service (equivalent to nil).
+    local addrs = assert(addrinfo.getaddrinfo('127.0.0.1', '', {
+        family = 'inet',
+        socktype = 'stream',
+    }))
+    assert.greater(#addrs, 0)
 end

--- a/test/addrinfo_test.lua
+++ b/test/addrinfo_test.lua
@@ -2,7 +2,6 @@ require('luacov')
 local testcase = require('testcase')
 local errno = require('errno')
 local errno_eai = require('errno.eai')
-local net = require('net')
 local addrinfo = require('net.addrinfo')
 
 --
@@ -32,11 +31,11 @@ function testcase.inet()
     -- socktype/protocol/canonname all return the expected defaults.
     local ai = assert(addrinfo.inet('127.0.0.1', 8080))
     assert.match(tostring(ai), '^net.addrinfo: ', false)
-    assert.equal(ai:family(), net.AF_INET)
+    assert.equal(ai:family(), 'inet')
     assert.equal(ai:addr(), '127.0.0.1')
     assert.equal(ai:port(), 8080)
-    assert.equal(ai:socktype(), 0)
-    assert.equal(ai:protocol(), 0)
+    assert.equal(ai:socktype(), 'unspec')
+    assert.equal(ai:protocol(), 'auto')
     assert.is_nil(ai:canonname())
 end
 
@@ -54,15 +53,15 @@ function testcase.inet_opts_socktype_protocol()
         socktype = 'stream',
         protocol = 'tcp',
     }))
-    assert.equal(ai:socktype(), net.SOCK_STREAM)
-    assert.equal(ai:protocol(), net.IPPROTO_TCP)
+    assert.equal(ai:socktype(), 'stream')
+    assert.equal(ai:protocol(), 'tcp')
 
     ai = assert(addrinfo.inet('127.0.0.1', 53, {
         socktype = 'dgram',
         protocol = 'udp',
     }))
-    assert.equal(ai:socktype(), net.SOCK_DGRAM)
-    assert.equal(ai:protocol(), net.IPPROTO_UDP)
+    assert.equal(ai:socktype(), 'dgram')
+    assert.equal(ai:protocol(), 'udp')
 end
 
 function testcase.inet_invalid_address()
@@ -113,7 +112,7 @@ function testcase.inet_ignores_unknown_opts()
     local ai = assert(addrinfo.inet('127.0.0.1', 0, {
         typo_option = true,
     }))
-    assert.equal(ai:family(), net.AF_INET)
+    assert.equal(ai:family(), 'inet')
 end
 
 function testcase.inet_opts_must_be_table()
@@ -130,7 +129,7 @@ end
 function testcase.inet6()
     -- Create an IPv6 addrinfo with the default options.
     local ai = assert(addrinfo.inet6('::1', 8080))
-    assert.equal(ai:family(), net.AF_INET6)
+    assert.equal(ai:family(), 'inet6')
     assert.equal(ai:addr(), '::1')
     assert.equal(ai:port(), 8080)
 end
@@ -149,8 +148,8 @@ function testcase.inet6_opts_socktype_protocol()
         socktype = 'stream',
         protocol = 'tcp',
     }))
-    assert.equal(ai:socktype(), net.SOCK_STREAM)
-    assert.equal(ai:protocol(), net.IPPROTO_TCP)
+    assert.equal(ai:socktype(), 'stream')
+    assert.equal(ai:protocol(), 'tcp')
 end
 
 function testcase.inet6_invalid_address()
@@ -166,15 +165,16 @@ end
 --
 function testcase.unix()
     -- Create an AF_UNIX addrinfo from a pathname.  addrinfo:family/addr
-    -- reflect AF_UNIX and the given path; port is nil because unix sockets
-    -- do not have a port.  socktype and protocol default to 0.
+    -- reflect the "unix" family and the given path; port is nil because unix
+    -- sockets do not have a port.  socktype and protocol use symbolic
+    -- defaults.
     local path = tmpsock()
     local ai = assert(addrinfo.unix(path))
-    assert.equal(ai:family(), net.AF_UNIX)
+    assert.equal(ai:family(), 'unix')
     assert.equal(ai:addr(), path)
     assert.is_nil(ai:port())
-    assert.equal(ai:socktype(), 0)
-    assert.equal(ai:protocol(), 0)
+    assert.equal(ai:socktype(), 'unspec')
+    assert.equal(ai:protocol(), 'auto')
 end
 
 function testcase.unix_opts_socktype()
@@ -183,7 +183,7 @@ function testcase.unix_opts_socktype()
     local ai = assert(addrinfo.unix(path, {
         socktype = 'stream',
     }))
-    assert.equal(ai:socktype(), net.SOCK_STREAM)
+    assert.equal(ai:socktype(), 'stream')
 end
 
 function testcase.unix_pathname_too_long()
@@ -216,9 +216,9 @@ function testcase.getaddrinfo()
     }))
     assert.greater(#addrs, 0)
     for _, ai in ipairs(addrs) do
-        assert.equal(ai:family(), net.AF_INET)
-        assert.equal(ai:socktype(), net.SOCK_STREAM)
-        assert.equal(ai:protocol(), net.IPPROTO_TCP)
+        assert.equal(ai:family(), 'inet')
+        assert.equal(ai:socktype(), 'stream')
+        assert.equal(ai:protocol(), 'tcp')
     end
 end
 
@@ -280,9 +280,9 @@ function testcase.inet_typed_convenience()
         socktype = 'stream',
         protocol = 'tcp',
     }))
-    assert.equal(ai:family(), net.AF_INET)
-    assert.equal(ai:socktype(), net.SOCK_STREAM)
-    assert.equal(ai:protocol(), net.IPPROTO_TCP)
+    assert.equal(ai:family(), 'inet')
+    assert.equal(ai:socktype(), 'stream')
+    assert.equal(ai:protocol(), 'tcp')
     assert.equal(ai:addr(), '127.0.0.1')
     assert.equal(ai:port(), 8080)
 end
@@ -315,8 +315,8 @@ function testcase.inet_typed_convenience_dgram()
         socktype = 'dgram',
         protocol = 'udp',
     }))
-    assert.equal(ai:socktype(), net.SOCK_DGRAM)
-    assert.equal(ai:protocol(), net.IPPROTO_UDP)
+    assert.equal(ai:socktype(), 'dgram')
+    assert.equal(ai:protocol(), 'udp')
 end
 
 function testcase.inet6_typed_convenience()
@@ -325,9 +325,9 @@ function testcase.inet6_typed_convenience()
         socktype = 'stream',
         protocol = 'tcp',
     }))
-    assert.equal(ai:family(), net.AF_INET6)
-    assert.equal(ai:socktype(), net.SOCK_STREAM)
-    assert.equal(ai:protocol(), net.IPPROTO_TCP)
+    assert.equal(ai:family(), 'inet6')
+    assert.equal(ai:socktype(), 'stream')
+    assert.equal(ai:protocol(), 'tcp')
     assert.equal(ai:addr(), '::1')
     assert.equal(ai:port(), 8080)
 end
@@ -338,8 +338,8 @@ function testcase.inet6_typed_convenience_dgram()
         socktype = 'dgram',
         protocol = 'udp',
     }))
-    assert.equal(ai:socktype(), net.SOCK_DGRAM)
-    assert.equal(ai:protocol(), net.IPPROTO_UDP)
+    assert.equal(ai:socktype(), 'dgram')
+    assert.equal(ai:protocol(), 'udp')
 end
 
 --
@@ -352,8 +352,8 @@ function testcase.unix_typed_convenience()
     local ai = assert(addrinfo.unix(path, {
         socktype = 'stream',
     }))
-    assert.equal(ai:family(), net.AF_UNIX)
-    assert.equal(ai:socktype(), net.SOCK_STREAM)
+    assert.equal(ai:family(), 'unix')
+    assert.equal(ai:socktype(), 'stream')
     assert.equal(ai:addr(), path)
 end
 
@@ -363,7 +363,7 @@ function testcase.unix_typed_convenience_dgram()
     local ai = assert(addrinfo.unix(path, {
         socktype = 'dgram',
     }))
-    assert.equal(ai:socktype(), net.SOCK_DGRAM)
+    assert.equal(ai:socktype(), 'dgram')
 end
 
 function testcase.unix_typed_convenience_pathname_too_long()
@@ -418,31 +418,30 @@ function testcase.getaddrinfo_canonname_must_be_boolean()
 end
 
 function testcase.family()
-    -- family() returns the AF_* constant of the addrinfo.
+    -- family() returns the symbolic address-family name.
     local ai = assert(addrinfo.inet('127.0.0.1', 8080, {
         socktype = 'stream',
         protocol = 'tcp',
     }))
-    assert.equal(ai:family(), net.AF_INET)
+    assert.equal(ai:family(), 'inet')
 end
 
 function testcase.socktype()
-    -- socktype() returns the SOCK_* constant configured via opts.socktype.
+    -- socktype() returns the symbolic name configured via opts.socktype.
     local ai = assert(addrinfo.inet('127.0.0.1', 8080, {
         socktype = 'stream',
         protocol = 'tcp',
     }))
-    assert.equal(ai:socktype(), net.SOCK_STREAM)
+    assert.equal(ai:socktype(), 'stream')
 end
 
 function testcase.protocol()
-    -- protocol() returns the IPPROTO_* constant configured via
-    -- opts.protocol.
+    -- protocol() returns the symbolic name configured via opts.protocol.
     local ai = assert(addrinfo.inet('127.0.0.1', 8080, {
         socktype = 'stream',
         protocol = 'tcp',
     }))
-    assert.equal(ai:protocol(), net.IPPROTO_TCP)
+    assert.equal(ai:protocol(), 'tcp')
 end
 
 function testcase.addr()

--- a/test/addrinfo_test.lua
+++ b/test/addrinfo_test.lua
@@ -89,13 +89,11 @@ function testcase.inet()
     end)
     assert.match(err, 'flags', false)
 
-    -- test that unknown opts key throws an error
-    err = assert.throws(function()
-        addrinfo.inet('127.0.0.1', 0, {
-            typo_option = true,
-        })
-    end)
-    assert.match(err, 'typo_option', false)
+    -- test that unknown opts keys are silently ignored
+    ai = assert(addrinfo.inet('127.0.0.1', 0, {
+        typo_option = true,
+    }))
+    assert.equal(ai:family(), net.AF_INET)
 
     -- test that opts must be a table
     err = assert.throws(function()
@@ -209,13 +207,11 @@ function testcase.getaddrinfo()
     end)
     assert.match(err, 'family', false)
 
-    -- test that unknown opts key throws
-    err = assert.throws(function()
-        addrinfo.getaddrinfo('127.0.0.1', 0, {
-            typo = 1,
-        })
-    end)
-    assert.match(err, 'typo', false)
+    -- test that unknown opts keys are silently ignored
+    local ok = assert(addrinfo.getaddrinfo('127.0.0.1', 0, {
+        typo = 1,
+    }))
+    assert.greater(#ok, 0)
 end
 
 --


### PR DESCRIPTION
## Summary

- prepare ignore rules and coverage generation for the native helper sources
- extract reusable option parsing and addrinfo construction helpers
- return symbolic names from addrinfo family, socket type, and protocol accessors
- centralize addrinfo constant and resolver flag lookups in `src/constants.c`
