### PR TITLE
Fix sendmsg cmsg stack overflow and remove 4 KiB cap

### DIFF
--- a/src/cmsghdr.c
+++ b/src/cmsghdr.c
@@ -23,136 +23,202 @@
 // project
 #include "constants.h"
 #include "net_socket.h"
+// system
+#include <limits.h>
+
+// Push an lstring holding a single, self-contained cmsg block (header +
+// payload + CMSG_ALIGN trailing padding) onto the top of L.  On Lua 5.2+ the
+// bytes are assembled directly inside a luaL_Buffer reservation, so only a
+// single Lua string allocation is performed.  On Lua 5.1 (no
+// `luaL_buffinitsize`) we fall back to a transient lua_newuserdata scratch
+// that is discarded once its bytes have been copied into the immutable Lua
+// string on top of the stack.
+static void push_cmsg_block(lua_State *L, int level, int type,
+                            const void *payload, size_t datalen)
+{
+    size_t space        = CMSG_SPACE(datalen);
+    unsigned char *dst  = NULL;
+    struct cmsghdr *cmh = NULL;
+
+#if LUA_VERSION_NUM >= 502
+    luaL_Buffer B;
+    dst = (unsigned char *)luaL_buffinitsize(L, &B, space);
+#else
+    dst = (unsigned char *)lua_newuserdata(L, space);
+#endif
+
+    memset(dst, 0, space);
+    cmh             = (struct cmsghdr *)dst;
+    cmh->cmsg_len   = CMSG_LEN(datalen);
+    cmh->cmsg_level = level;
+    cmh->cmsg_type  = type;
+    if (datalen > 0) {
+        memcpy(CMSG_DATA(cmh), payload, datalen);
+    }
+
+#if LUA_VERSION_NUM >= 502
+    luaL_pushresultsize(&B, space);
+#else
+    lua_pushlstring(L, (const char *)dst, space);
+    // Discard the scratch userdata now that its bytes have been copied into
+    // the immutable Lua string on top of the stack.
+    lua_replace(L, -2);
+#endif
+}
 
 // Maximum number of file descriptors that can be sent in a single SCM_RIGHTS
 // cmsg.  Linux caps this at SCM_MAX_FD (253); the value used here is
 // deliberately generous so the fd array fits on the stack for typical use.
 #define NET_CMSG_MAX_FD 256
 
-// Serialize a single cmsg entry (already parsed level/type) whose payload is
-// held at Lua stack index dataidx into the destination buffer.  On error, this
-// function raises via luaL_error and does not return.
-static size_t write_cmsg_entry(lua_State *L, int cmsg_index_for_error,
-                               int level, int type, int dataidx,
-                               unsigned char *buf, size_t used, size_t bufsize)
+// Read the SCM_RIGHTS payload at Lua stack index `dataidx` (an integer fd or
+// an integer[] table of fds) and push a serialized cmsg block onto L.  Raises
+// via luaL_error on malformed data.
+static void push_scm_rights_entry(lua_State *L, int i, int level, int type,
+                                  int dataidx)
 {
-    struct cmsghdr *cmh = (struct cmsghdr *)(buf + used);
-    size_t space        = 0;
+    int fds[NET_CMSG_MAX_FD];
+    size_t nfd = 0;
 
-    if (level == SOL_SOCKET && type == SCM_RIGHTS) {
-        int fds[NET_CMSG_MAX_FD];
-        size_t nfd = 0;
-        int dtype  = lua_type(L, dataidx);
-        if (dtype == LUA_TNUMBER) {
-            fds[0] = (int)lua_tointeger(L, dataidx);
-            nfd    = 1;
-        } else if (dtype == LUA_TTABLE) {
-            lua_Integer tlen = (lua_Integer)lauxh_rawlen(L, dataidx);
-            if (tlen < 0 || (size_t)tlen > NET_CMSG_MAX_FD) {
-                luaL_error(L, "cmsg[%d].data: too many fds (max %d)",
-                           cmsg_index_for_error, (int)NET_CMSG_MAX_FD);
+    switch (lua_type(L, dataidx)) {
+    case LUA_TNUMBER:
+        fds[0] = (int)lua_tointeger(L, dataidx);
+        nfd    = 1;
+        break;
+
+    case LUA_TTABLE: {
+        lua_Integer tlen = (lua_Integer)lauxh_rawlen(L, dataidx);
+        if (tlen < 0 || (size_t)tlen > NET_CMSG_MAX_FD) {
+            luaL_error(L, "cmsg[%d].data: too many fds (max %d)", i,
+                       (int)NET_CMSG_MAX_FD);
+        }
+        for (lua_Integer j = 1; j <= tlen; j++) {
+            lua_rawgeti(L, dataidx, (int)j);
+            if (lua_type(L, -1) != LUA_TNUMBER) {
+                luaL_error(L, "cmsg[%d].data[%d] must be integer fd", i,
+                           (int)j);
             }
-            for (lua_Integer j = 1; j <= tlen; j++) {
-                lua_rawgeti(L, dataidx, (int)j);
-                if (lua_type(L, -1) != LUA_TNUMBER) {
-                    luaL_error(L, "cmsg[%d].data[%d] must be integer fd",
-                               cmsg_index_for_error, (int)j);
-                }
-                fds[j - 1] = (int)lua_tointeger(L, -1);
-                lua_pop(L, 1);
-            }
-            nfd = (size_t)tlen;
-        } else {
-            luaL_error(L,
-                       "cmsg[%d].data: SCM_RIGHTS requires integer fd or "
-                       "table of integer fds",
-                       cmsg_index_for_error);
+            fds[j - 1] = (int)lua_tointeger(L, -1);
+            lua_pop(L, 1);
         }
-        // Reserve space for the cmsg header and its file descriptor payload.
-        // Note that SCM_MAX_FD (253 on Linux) fds fit within a few hundred
-        // bytes even after CMSG_SPACE alignment, well below sendmsg_lua's
-        // 4 KiB control buffer, so we do not need an explicit overflow
-        // guard here (the fd count check above is the effective bound).
-        space           = CMSG_SPACE(sizeof(int) * nfd);
-        cmh->cmsg_len   = CMSG_LEN(sizeof(int) * nfd);
-        cmh->cmsg_level = level;
-        cmh->cmsg_type  = type;
-        memcpy(CMSG_DATA(cmh), fds, sizeof(int) * nfd);
-    } else {
-        size_t datalen   = 0;
-        const char *dbuf = NULL;
-        if (lua_type(L, dataidx) != LUA_TSTRING) {
-            luaL_error(L, "cmsg[%d].data: string expected for level=%d type=%d",
-                       cmsg_index_for_error, level, type);
-        }
-        dbuf  = lua_tolstring(L, dataidx, &datalen);
-        space = CMSG_SPACE(datalen);
-        if (used + space > bufsize) {
-            luaL_error(L, "cmsg buffer overflow at cmsg[%d]",
-                       cmsg_index_for_error);
-        }
-        cmh->cmsg_len   = CMSG_LEN(datalen);
-        cmh->cmsg_level = level;
-        cmh->cmsg_type  = type;
-        memcpy(CMSG_DATA(cmh), dbuf, datalen);
+        nfd = (size_t)tlen;
+    } break;
+
+    default:
+        luaL_error(L,
+                   "cmsg[%d].data: SCM_RIGHTS requires integer fd or "
+                   "table of integer fds",
+                   i);
     }
-    return space;
+
+    push_cmsg_block(L, level, type, fds, sizeof(int) * nfd);
 }
 
-size_t net_cmsg_build_buffer(lua_State *L, int idx, unsigned char *buf,
-                             size_t bufsize)
+// Read a raw (non-SCM_RIGHTS) cmsg payload string at Lua stack index
+// `dataidx` and push a serialized cmsg block onto L.  Raises via luaL_error
+// when the data field is not a string.
+static void push_raw_cmsg_entry(lua_State *L, int i, int level, int type,
+                                int dataidx)
+{
+    size_t datalen   = 0;
+    const char *dbuf = NULL;
+
+    if (lua_type(L, dataidx) != LUA_TSTRING) {
+        luaL_error(L, "cmsg[%d].data: string expected for level=%d type=%d", i,
+                   level, type);
+    }
+    dbuf = lua_tolstring(L, dataidx, &datalen);
+    push_cmsg_block(L, level, type, dbuf, datalen);
+}
+
+// Serialize one cmsg entry into a fresh Lua string and leave that string on
+// top of the Lua stack, replacing the input cmsg descriptor table at
+// `cmsg_idx`.  Level, type and data fields are read from the table and any
+// transient stack slots are cleaned up before returning.  On error, this
+// function raises via luaL_error and does not return.
+static void push_cmsg_entry(lua_State *L, int cmsg_idx, int i)
+{
+    int level             = 0;
+    int type              = 0;
+    int dataidx           = 0;
+    const char *level_str = NULL;
+    const char *type_str  = NULL;
+
+    if (!lua_istable(L, cmsg_idx)) {
+        luaL_error(L, "cmsg[%d] must be a table", i);
+    }
+
+    // level
+    lua_getfield(L, cmsg_idx, "level");
+    if (lua_type(L, -1) != LUA_TSTRING) {
+        luaL_error(L, "cmsg[%d].level must be a string", i);
+    }
+    level_str = lua_tostring(L, -1);
+    if (!net_cmsg_level_value(level_str, &level)) {
+        luaL_error(L, "cmsg[%d].level: unknown level '%s'", i, level_str);
+    }
+    lua_pop(L, 1);
+
+    // type
+    lua_getfield(L, cmsg_idx, "type");
+    if (lua_type(L, -1) != LUA_TSTRING) {
+        luaL_error(L, "cmsg[%d].type must be a string", i);
+    }
+    type_str = lua_tostring(L, -1);
+    if (!net_cmsg_type_value(level, type_str, &type)) {
+        luaL_error(L, "cmsg[%d].type: unknown type '%s' for level '%s'", i,
+                   type_str, level_str);
+    }
+    lua_pop(L, 1);
+
+    // data
+    lua_getfield(L, cmsg_idx, "data");
+    dataidx = lua_gettop(L);
+
+    if (level == SOL_SOCKET && type == SCM_RIGHTS) {
+        push_scm_rights_entry(L, i, level, type, dataidx);
+    } else {
+        push_raw_cmsg_entry(L, i, level, type, dataidx);
+    }
+
+    // Stack now: [..., cmsg_table (cmsg_idx), data, cmsg_lstring]
+    // Replace the cmsg descriptor table with the assembled lstring so that
+    // after cleanup only the lstring remains at cmsg_idx.
+    lua_replace(L, cmsg_idx);
+    // Pop the data field slot.
+    // Stack now: [..., cmsg_lstring (cmsg_idx)]
+    lua_pop(L, 1);
+}
+
+int net_cmsg_build_buffer(lua_State *L, int idx)
 {
     lua_Integer n = (lua_Integer)lauxh_rawlen(L, idx);
-    size_t used   = 0;
 
     if (n <= 0) {
         return 0;
     }
-    memset(buf, 0, bufsize);
+    // LCOV_EXCL_START - defensive cap for pathologically large cmsg tables.
+    // In practice sendmsg(2) cmsg counts are single digits and luaL_checkstack
+    // below would fail long before INT_MAX / 2 is reached; the check exists
+    // only to make the subsequent (int) casts well-defined.
+    if (n > INT_MAX / 2) {
+        luaL_error(L, "cmsg table too large: %d entries", (int)INT_MAX);
+    }
+    // LCOV_EXCL_STOP
+
+    // Reserve stack room for n accumulated lstrings plus per-iteration
+    // temporaries (cmsg table, data value, scratch userdata, lstring).
+    luaL_checkstack(L, (int)n + 4, "cmsg buffer build");
 
     for (lua_Integer i = 1; i <= n; i++) {
         lua_rawgeti(L, idx, (int)i);
-        int cmsg_idx = lua_gettop(L);
-        if (!lua_istable(L, cmsg_idx)) {
-            luaL_error(L, "cmsg[%d] must be a table", (int)i);
-        }
-
-        // level
-        lua_getfield(L, cmsg_idx, "level");
-        if (lua_type(L, -1) != LUA_TSTRING) {
-            luaL_error(L, "cmsg[%d].level must be a string", (int)i);
-        }
-        const char *level_str = lua_tostring(L, -1);
-        int level             = 0;
-        if (!net_cmsg_level_value(level_str, &level)) {
-            luaL_error(L, "cmsg[%d].level: unknown level '%s'", (int)i,
-                       level_str);
-        }
-        lua_pop(L, 1);
-
-        // type
-        lua_getfield(L, cmsg_idx, "type");
-        if (lua_type(L, -1) != LUA_TSTRING) {
-            luaL_error(L, "cmsg[%d].type must be a string", (int)i);
-        }
-        const char *type_str = lua_tostring(L, -1);
-        int type             = 0;
-        if (!net_cmsg_type_value(level, type_str, &type)) {
-            luaL_error(L, "cmsg[%d].type: unknown type '%s' for level '%s'",
-                       (int)i, type_str, level_str);
-        }
-        lua_pop(L, 1);
-
-        // data
-        lua_getfield(L, cmsg_idx, "data");
-        int dataidx = lua_gettop(L);
-        size_t adv  = write_cmsg_entry(L, (int)i, level, type, dataidx, buf,
-                                       used, bufsize);
-        used += adv;
-        lua_pop(L, 1); // data
-        lua_pop(L, 1); // cmsg_idx table
+        push_cmsg_entry(L, lua_gettop(L), (int)i);
     }
-    return used;
+
+    if (n > 1) {
+        lua_concat(L, (int)n);
+    }
+    return 1;
 }
 
 /**

--- a/src/net_socket.h
+++ b/src/net_socket.h
@@ -95,7 +95,8 @@ LUALIB_API int luaopen_net_socket(lua_State *L);
 // cmsg helpers (implemented in src/cmsghdr.c)
 
 /**
- * @brief Build a struct cmsghdr[] buffer from a Lua table of cmsg descriptors.
+ * @brief Build a struct cmsghdr[] control buffer from a Lua table of cmsg
+ * descriptors and push it onto the Lua stack as a single string.
  *
  * The table at Lua stack index `idx` is expected to be an array of tables of
  * the form `{ level = <string>, type = <string>, data =
@@ -108,18 +109,21 @@ LUALIB_API int luaopen_net_socket(lua_State *L);
  *   - `("socket", "rights")` -> integer fd or table of fds (SCM_RIGHTS)
  *   - otherwise               -> raw string bytes copied into the cmsg
  *
- * The serialized bytes are written to `buf` and the number of used bytes is
- * returned.  On any conversion error this function raises a Lua error via
- * `luaL_error` and does not return.
+ * Each cmsg entry is serialized into an exact CMSG_SPACE-sized Lua string,
+ * and the strings are concatenated (via `lua_concat`) into a single string
+ * whose bytes can be used directly as `msg_control` / `msg_controllen`.
+ * Lua string content is aligned to `L_Umaxalign` (>= sizeof(long)), which
+ * satisfies `struct cmsghdr` alignment on all supported platforms.
  *
- * @param L       Lua state.
- * @param idx     Absolute Lua stack index of the cmsg table.
- * @param buf     Destination buffer (must be at least `bufsize` bytes).
- * @param bufsize Size of the destination buffer in bytes.
- * @return Number of bytes written to `buf` (0 if the input table is empty).
+ * @param L   Lua state.
+ * @param idx Absolute Lua stack index of the cmsg table.
+ * @return 1 if a control-buffer string was pushed onto L (the caller must
+ *         obtain the pointer/length via `lua_tolstring(L, -1, &len)` and pop
+ *         the string with `lua_pop(L, 1)` after sendmsg(2) returns), or 0 if
+ *         the input table is empty (nothing pushed).  On invalid input this
+ *         function raises via `luaL_error` and does not return.
  */
-size_t net_cmsg_build_buffer(lua_State *L, int idx, unsigned char *buf,
-                             size_t bufsize);
+int net_cmsg_build_buffer(lua_State *L, int idx);
 
 /**
  * @brief Convert the ancillary data recorded in a struct msghdr into a Lua
@@ -130,7 +134,8 @@ size_t net_cmsg_build_buffer(lua_State *L, int idx, unsigned char *buf,
  * known, `level` and `type` use short lowercase names; otherwise the raw
  * integer values are used.  The `data` field is special-cased as follows:
  *
- *   - `SCM_RIGHTS`   -> integer fd (single fd) or integer[] table (multiple fds)
+ *   - `SCM_RIGHTS`   -> integer fd (single fd) or integer[] table (multiple
+ *                       fds)
  *   - `SCM_TIMESTAMP`-> table `{ sec = <integer>, usec = <integer> }`
  *   - otherwise      -> string (raw payload)
  *

--- a/src/socket.c
+++ b/src/socket.c
@@ -23,9 +23,9 @@
  */
 
 // project
+#include "constants.h"
 #include "net_socket.h"
 #include "optcheck.h"
-#include "constants.h"
 #include "sockopts.h"
 // depends
 #include "lauxhlib.h"
@@ -1405,12 +1405,6 @@ static int sendfd_lua(lua_State *L)
     }
 }
 
-// Maximum size of the ancillary (control) buffer used when serializing cmsgs
-// for sendmsg(2).  This bounds the total size of all cmsgs combined; the
-// default is large enough to hold ~1000 file descriptors in SCM_RIGHTS which
-// far exceeds the practical Linux SCM_MAX_FD limit (253).
-#define NET_SENDMSG_CBUF_SIZE 4096
-
 static int sendmsg_lua(lua_State *L)
 {
     net_socket_t *s      = lauxh_checkudata(L, 1, SOCKET_MT);
@@ -1420,10 +1414,8 @@ static int sendmsg_lua(lua_State *L)
     // arg 3: net.addrinfo (optional; destination address)
     net_addrinfo_t *addr = lauxh_optudata(L, 3, NET_ADDRINFO_MT, NULL);
     // arg 4: cmsg table (optional; ancillary data descriptors)
-    unsigned char control[NET_SENDMSG_CBUF_SIZE] = {0};
-    size_t controllen                            = 0;
-    int flgs                                     = 0;
-    struct iovec iov                             = {
+    int flgs             = 0;
+    struct iovec iov     = {
         .iov_base = (void *)msgbuf,
         .iov_len  = msglen,
     };
@@ -1436,23 +1428,35 @@ static int sendmsg_lua(lua_State *L)
         .msg_controllen = 0,
         .msg_flags      = 0,
     };
-    ssize_t rv = 0;
+    int has_cmsgs = 0;
+    ssize_t rv    = 0;
 
-    // arg 4: cmsg table (optional; ancillary data descriptors)
+    // arg 4: check cmsg table (optional; ancillary data descriptors) specified
     if (!lua_isnoneornil(L, 4)) {
         luaL_checktype(L, 4, LUA_TTABLE);
-        controllen = net_cmsg_build_buffer(L, 4, control, sizeof(control));
+        has_cmsgs = 1;
+    }
+
+    // args 5+: flags.  Parse flag arguments before pushing the assembled cmsg
+    // control-buffer string, so that net_check_msgflags does not scan past
+    // the actual sendmsg arguments and pick up the pushed string as an
+    // additional flag.
+    flgs = net_check_msgflags(L, 5);
+
+    // arg 4: build cmsg control-buffer string
+    if (has_cmsgs && net_cmsg_build_buffer(L, 4)) {
+        size_t controllen  = 0;
+        const char *ctlbuf = lua_tolstring(L, -1, &controllen);
         if (controllen > 0) {
-            data.msg_control    = control;
+            data.msg_control    = (void *)ctlbuf;
             data.msg_controllen = (socklen_t)controllen;
         }
     }
-    // args 5+: flags
-    flgs = net_check_msgflags(L, 5);
 
-    if (msgbuf == NULL && controllen == 0) {
+    if (msgbuf == NULL && data.msg_controllen == 0) {
         // Nothing to send.  Match the send()/sendto() convention of raising
         // EINVAL rather than silently succeeding.
+        lua_settop(L, 0);
         lua_pushnil(L);
         errno = EINVAL;
         lua_errno_new(L, errno, "sendmsg");
@@ -1461,7 +1465,9 @@ static int sendmsg_lua(lua_State *L)
 
     rv = sendmsg(s->fd, &data, flgs);
     if (rv == -1) {
-        if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+        int err = errno;
+        lua_settop(L, 0);
+        if (err == EAGAIN || err == EWOULDBLOCK || err == EINTR) {
             lua_pushinteger(L, 0);
             lua_pushnil(L);
             lua_pushboolean(L, 1);
@@ -1469,7 +1475,7 @@ static int sendmsg_lua(lua_State *L)
         }
         // Got error (closed by peer: EPIPE || ECONNRESET)
         lua_pushnil(L);
-        lua_errno_new(L, errno, "sendmsg");
+        lua_errno_new(L, err, "sendmsg");
         return 2;
     }
     lua_pushinteger(L, rv);
@@ -2153,7 +2159,7 @@ static int bind_lua(lua_State *L)
 
 static int protocol_lua(lua_State *L)
 {
-    net_socket_t *s = lauxh_checkudata(L, 1, SOCKET_MT);
+    net_socket_t *s  = lauxh_checkudata(L, 1, SOCKET_MT);
     const char *name = net_protocol_name(s->protocol);
 
     if (!name) {
@@ -2165,7 +2171,7 @@ static int protocol_lua(lua_State *L)
 
 static int socktype_lua(lua_State *L)
 {
-    net_socket_t *s = lauxh_checkudata(L, 1, SOCKET_MT);
+    net_socket_t *s  = lauxh_checkudata(L, 1, SOCKET_MT);
     const char *name = net_socktype_name(s->socktype);
 
     if (!name) {
@@ -2177,7 +2183,7 @@ static int socktype_lua(lua_State *L)
 
 static int family_lua(lua_State *L)
 {
-    net_socket_t *s = lauxh_checkudata(L, 1, SOCKET_MT);
+    net_socket_t *s  = lauxh_checkudata(L, 1, SOCKET_MT);
     const char *name = net_family_name(s->family);
 
     if (!name) {

--- a/test/socket_test.lua
+++ b/test/socket_test.lua
@@ -3635,30 +3635,79 @@ function testcase.sendmsg_cmsg_invalid_arguments()
     b:close()
 end
 
-function testcase.sendmsg_cmsg_invalid_raw_buffer_overflow()
-    -- test that write_cmsg_entry raises when a raw-string cmsg payload
-    -- exceeds sendmsg_lua's 4 KiB control buffer.  We pick level='ip' /
-    -- type='ttl' because SOL_IP allows raw-string cmsg payloads via the
-    -- generic path.  The size (>4 KiB) is chosen to guarantee overflow.
+function testcase.sendmsg_cmsg_supports_control_block_beyond_stack_cap()
+    -- write_cmsg_entry historically wrote each cmsg entry into a fixed
+    -- 4 KiB stack control buffer inside sendmsg_lua, so a raw cmsg whose
+    -- CMSG_SPACE exceeded 4 KiB failed with a client-side "buffer
+    -- overflow" Lua error.  Ancillary data is now assembled as a Lua
+    -- string per entry and concatenated, so a >4 KiB raw cmsg is passed
+    -- through to sendmsg(2) instead of being rejected before the call.
+    -- The kernel is free to accept or reject the oversized cmsg (a wrong-
+    -- size IP_TTL typically surfaces EINVAL); what matters is that no
+    -- Lua exception with the old "buffer overflow" message is raised.
     local socks = assert(socket.pair({
         socktype = 'stream',
     }))
     local a = socks[1]
     local b = socks[2]
 
-    local err = assert.throws(function()
-        a:sendmsg('x', nil, {
-            {
-                level = 'ip',
-                type = 'ttl',
-                data = string.rep('x', 5000),
-            },
-        })
-    end)
-    assert.match(err, 'buffer overflow', false)
+    -- Wrapped in pcall so that any thrown error can be inspected.  The
+    -- library must not raise; a wrongly-sized TTL cmsg surfaces as a
+    -- normal (nil, errno) return pair.
+    local ok, len, err = pcall(a.sendmsg, a, 'x', nil, {
+        {
+            level = 'ip',
+            type = 'ttl',
+            data = string.rep('x', 5000),
+        },
+    })
+    assert.is_true(ok, 'sendmsg must not raise for oversized raw cmsg')
+    -- Either sendmsg succeeds (some kernels ignore the wrong size) or
+    -- returns nil + errno; both are acceptable so long as no Lua-level
+    -- buffer overflow is raised.
+    if not len then
+        assert.not_nil(err)
+    end
 
     a:close()
     b:close()
+end
+
+function testcase.sendmsg_cmsg_concatenates_multiple_entries()
+    -- When more than one cmsg descriptor is supplied, each entry is
+    -- serialized into its own Lua string and the strings are then
+    -- concatenated via lua_concat() to produce a single control-buffer
+    -- block.  Exercise that concatenation path with two IP_TTL cmsg
+    -- entries on a UDP socket so that the assembled block reaches the
+    -- kernel and the send succeeds.
+    local server = assert(socket.bind_inet('127.0.0.1', 0, {
+        socktype = 'dgram',
+        protocol = 'udp',
+    }))
+    local sai = assert(server:getsockname())
+    local client = assert(socket.new_inet({
+        socktype = 'dgram',
+        protocol = 'udp',
+    }))
+
+    local ttl_bytes = string.char(64, 0, 0, 0)
+    local len, err = client:sendmsg('m', sai, {
+        {
+            level = 'ip',
+            type = 'ttl',
+            data = ttl_bytes,
+        },
+        {
+            level = 'ip',
+            type = 'ttl',
+            data = ttl_bytes,
+        },
+    })
+    assert(len, err)
+    assert.equal(len, 1)
+
+    client:close()
+    server:close()
 end
 
 function testcase.sendmsg_cmsg_invalid_unknown_type_on_tcp_level()
@@ -5095,15 +5144,12 @@ function testcase.message_flags_accept_string_names()
     assert.equal(assert(a:recv(1, 'peek', nil, 'dontwait', 'peek')), 'r')
     assert.equal(assert(a:recv(1)), 'r')
 
-    assert.equal(assert(a:sendmsg(
-        'm', nil, nil, 'dontwait', nil, 'dontwait'
-    )), 1)
+    assert.equal(assert(a:sendmsg('m', nil, nil, 'dontwait', nil, 'dontwait')),
+                 1)
     assert.equal(assert(b:recv(1)), 'm')
 
     assert.equal(assert(b:sendmsg('g')), 1)
-    local msg = assert(a:recvmsg(
-        1, 0, 'peek', nil, 'dontwait', 'peek'
-    ))
+    local msg = assert(a:recvmsg(1, 0, 'peek', nil, 'dontwait', 'peek'))
     assert.equal(msg.data, 'g')
     assert.equal(assert(a:recv(1)), 'g')
 
@@ -5119,9 +5165,8 @@ function testcase.message_flags_accept_string_names()
     b = socks[2]
     local f = assert(io.tmpfile())
 
-    assert.equal(assert(a:sendfd(
-        fileno(f), nil, 'dontwait', nil, 'dontwait'
-    )), 0)
+    assert.equal(assert(a:sendfd(fileno(f), nil, 'dontwait', nil, 'dontwait')),
+                 0)
     local fd = assert(b:recvfd('dontwait', nil, 'dontwait'))
     assert(socket.close(fd))
 
@@ -5144,9 +5189,7 @@ function testcase.message_flags_accept_string_names()
     local da = assert(socket.bind_unix(ai_a))
     local db = assert(socket.bind_unix(ai_b))
 
-    assert.equal(assert(da:sendto(
-        't', ai_b, 'dontwait', nil, 'dontwait'
-    )), 1)
+    assert.equal(assert(da:sendto('t', ai_b, 'dontwait', nil, 'dontwait')), 1)
     assert.equal(assert(db:recvfrom(1)), 't')
 
     da:close()
@@ -5162,9 +5205,7 @@ function testcase.message_flags_accept_string_names()
     a = socks[1]
     b = socks[2]
     assert.equal(assert(b:send('f')), 1)
-    assert.equal(assert(a:recvfrom(
-        1, 'peek', nil, 'dontwait', 'peek'
-    )), 'f')
+    assert.equal(assert(a:recvfrom(1, 'peek', nil, 'dontwait', 'peek')), 'f')
     assert.equal(assert(a:recv(1)), 'f')
     a:close()
     b:close()


### PR DESCRIPTION
The SCM_RIGHTS serializer never checked the cumulative CMSG_SPACE
against `sendmsg`'s fixed 4 KiB stack buffer, so passing several
SCM_RIGHTS entries whose combined space exceeded the buffer corrupted
the surrounding stack frame before `sendmsg(2)` was invoked.  The
buffer size was also unreachable from Lua, so any lawful cmsg block
above 4 KiB was rejected on the client side.
