### PR TITLE
Replace recvable/sendable select() call with poll()

### DIFF
--- a/src/net_socket.h
+++ b/src/net_socket.h
@@ -54,6 +54,7 @@
 #include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <poll.h>
 #include <signal.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/socket.c
+++ b/src/socket.c
@@ -31,6 +31,8 @@
 #include "lauxhlib.h"
 #include "lua_errno.h"
 #include "lua_error.h"
+// system
+#include <limits.h>
 
 #ifndef LUA_OK
 # define LUA_OK 0
@@ -2070,61 +2072,79 @@ static int connect_lua(lua_State *L)
     return 2;
 }
 
-static inline int select_lua(lua_State *L, int receivable, int sendable)
+static inline int poll_lua(lua_State *L, int receivable, int sendable)
 {
-    net_socket_t *s        = lauxh_checkudata(L, 1, SOCKET_MT);
-    lua_Number sec         = luaL_optnumber(L, 2, 0);
-    int except             = lauxh_optboolean(L, 3, 0);
-    struct timeval timeout = {.tv_sec = 0, .tv_usec = 0};
-    fd_set *rptr           = NULL;
-    fd_set *wptr           = NULL;
-    fd_set *eptr           = NULL;
-    fd_set rfds;
-    fd_set wfds;
-    fd_set efds;
+    net_socket_t *s   = lauxh_checkudata(L, 1, SOCKET_MT);
+    lua_Number sec    = luaL_optnumber(L, 2, 0);
+    int except        = lauxh_optboolean(L, 3, 0);
+    struct pollfd pfd = {
+        .fd      = s->fd,
+        .events  = 0,
+        .revents = 0,
+    };
+    int timeout_ms = 0;
+    int rv         = 0;
 
     lua_settop(L, 0);
-    if (sec > 0) {
-        timeout.tv_sec  = sec;
-        timeout.tv_usec = (sec - (lua_Number)timeout.tv_sec) * 1000000;
-    }
 
-    // select receivable
     if (receivable) {
-        rptr = &rfds;
-        FD_ZERO(rptr);
-        FD_SET(s->fd, rptr);
+        pfd.events |= POLLIN;
     }
-    // select sendable
     if (sendable) {
-        wptr = &wfds;
-        FD_ZERO(wptr);
-        FD_SET(s->fd, wptr);
+        pfd.events |= POLLOUT;
     }
-    // select exception
     if (except) {
-        eptr = &efds;
-        FD_ZERO(eptr);
-        FD_SET(s->fd, eptr);
+        // POLLPRI matches select's exception fd_set for out-of-band data.
+        pfd.events |= POLLPRI;
     }
 
-    // wait until usable or exceeded timeout
-    switch (select(s->fd + 1, rptr, wptr, eptr, &timeout)) {
+    // Convert `sec` (seconds, possibly fractional) into a millisecond
+    // timeout for poll(2).  Non-positive `sec` is an immediate check
+    // (timeout_ms = 0) matching the previous select()-based semantics.
+    if (sec > 0) {
+        double ms = sec * 1000.0;
+        if (ms >= (double)INT_MAX) {
+            timeout_ms = INT_MAX;
+        } else {
+            timeout_ms = (int)ms;
+            // Do not collapse a small positive `sec` into an immediate
+            // poll.
+            if (timeout_ms == 0) {
+                timeout_ms = 1;
+            }
+        }
+    }
+
+    rv = poll(&pfd, 1, timeout_ms);
+    switch (rv) {
     case 0:
-        // timeout
+        // Timeout: no requested event became ready within `sec`.  poll()
+        // ignores entries whose fd is negative, so a closed socket
+        // (fd == -1) follows this branch as well.
         lua_pushboolean(L, 0);
         lua_pushnil(L);
         lua_pushboolean(L, 1);
         return 3;
 
     case -1:
-        // got error
+        // errno set by poll(2) (e.g. EINTR); surface it directly.
         lua_pushboolean(L, 0);
-        lua_errno_new(L, errno, "select");
+        lua_errno_new(L, errno, "poll");
         return 2;
 
     default:
-        // selected
+        // POLLNVAL means the fd is not open (e.g. externally closed).
+        // Surface it as EBADF to match the previous select() -1 error
+        // path.
+        if (pfd.revents & POLLNVAL) {
+            lua_pushboolean(L, 0);
+            errno = EBADF;
+            lua_errno_new(L, errno, "poll");
+            return 2;
+        }
+        // POLLIN / POLLOUT / POLLPRI / POLLERR / POLLHUP all count as
+        // ready; a subsequent recv/send surfaces the real errno when the
+        // socket is only ready because of POLLERR or POLLHUP.
         lua_pushboolean(L, 1);
         return 1;
     }
@@ -2132,12 +2152,12 @@ static inline int select_lua(lua_State *L, int receivable, int sendable)
 
 static int sendable_lua(lua_State *L)
 {
-    return select_lua(L, 0, 1);
+    return poll_lua(L, 0, 1);
 }
 
 static int recvable_lua(lua_State *L)
 {
-    return select_lua(L, 1, 0);
+    return poll_lua(L, 1, 0);
 }
 
 static int bind_lua(lua_State *L)

--- a/test/socket_test.lua
+++ b/test/socket_test.lua
@@ -4400,19 +4400,19 @@ function testcase.sendable_recvable_basic()
     a:close()
     b:close()
 
-    -- After close, s->fd is -1 which makes select(0, ...) a timeout rather
-    -- than a hard error.  We still exercise the select() invocation path.
+    -- After close, s->fd is -1 which makes poll(2) ignore the entry and
+    -- return 0, driving the timeout branch.
     local rv = a:sendable(0)
     assert.is_false(rv)
 end
 
 function testcase.sendable_recvable_on_stale_fd()
-    -- Force select_lua's case -1 branch (EBADF):
+    -- Force poll_lua's POLLNVAL branch (EBADF):
     -- 1. create a real socket, then externally close its fd via
     --    socket.close(fd) so the userdata still holds a numerically valid
     --    but kernel-closed fd
-    -- 2. sendable/recvable then invoke select() on that stale fd and get
-    --    EBADF
+    -- 2. sendable/recvable then invoke poll() on that stale fd and get
+    --    POLLNVAL, which is surfaced as EBADF
     local s = assert(socket.new_inet({
         socktype = 'stream',
         protocol = 'tcp',
@@ -4435,11 +4435,12 @@ function testcase.sendable_recvable_on_stale_fd()
 end
 
 function testcase.sendable_recvable_on_closed_socket()
-    -- sendable/recvable both go through select_lua.  A closed socket has
-    -- fd == -1; select(0, ...) returns 0 which drives the timeout branch
-    -- (false, nil, true).  The -1 branch (EBADF etc.) requires an active
-    -- fd whose value has been externally closed, which is not reachable
-    -- from the public API.
+    -- sendable/recvable both go through poll_lua.  A closed socket has
+    -- fd == -1; poll(2) ignores entries with negative fd and returns 0
+    -- so the timeout branch (false, nil, true) is exercised.  The
+    -- POLLNVAL branch (EBADF etc.) requires an active fd whose value
+    -- has been externally closed, which is not reachable from the
+    -- public API.
     local s = assert(socket.new_inet({
         socktype = 'stream',
         protocol = 'tcp',
@@ -4454,7 +4455,7 @@ function testcase.sendable_recvable_on_closed_socket()
     assert.is_nil(err)
     assert.is_true(timeout)
     -- passing `except=true` as the third argument to sendable / recvable
-    -- also runs select_lua's exception-set setup path.
+    -- also runs poll_lua's exception-condition (POLLPRI) setup path.
     rv, err, timeout = s:sendable(0, true)
     assert.is_false(rv)
     assert.is_nil(err)
@@ -4463,6 +4464,51 @@ function testcase.sendable_recvable_on_closed_socket()
     assert.is_false(rv)
     assert.is_nil(err)
     assert.is_true(timeout)
+end
+
+function testcase.sendable_recvable_supports_high_fd_values()
+    -- The historical select(2) + fd_set implementation invoked undefined
+    -- behaviour when the socket's fd was >= FD_SETSIZE (typically 1024)
+    -- because FD_SET writes past the end of the local fd_set.  The
+    -- current implementation uses poll(2), whose struct pollfd carries
+    -- no such upper bound.  Consume file descriptors until any newly
+    -- created socket has an fd well above 1024 and verify that
+    -- sendable() / recvable() work correctly on that fd.  If the
+    -- process's RLIMIT_NOFILE is below the target the test releases its
+    -- hoard and silently skips the assertion so it does not perturb
+    -- constrained CI environments.
+    local target = 1030
+    local hoard  = {}
+    local a, b
+    while true do
+        local socks = socket.pair({
+            socktype = 'stream',
+        })
+        if not socks then
+            break
+        end
+        if math.max(socks[1]:fd(), socks[2]:fd()) >= target then
+            a = socks[1]
+            b = socks[2]
+            break
+        end
+        hoard[#hoard + 1] = socks[1]
+        hoard[#hoard + 1] = socks[2]
+    end
+
+    if a and b then
+        assert.is_true(a:sendable(0))
+        local ok, err, timeout = b:recvable(0.001)
+        assert.is_false(ok)
+        assert.is_nil(err)
+        assert.is_true(timeout)
+        a:close()
+        b:close()
+    end
+
+    for _, s in ipairs(hoard) do
+        s:close()
+    end
 end
 
 function testcase.getpeername_unconnected()


### PR DESCRIPTION
The recvable and sendable readiness helpers built a stack-allocated
fd_set and called FD_SET(s->fd, ...) without checking that s->fd was
below FD_SETSIZE.  On systems where the process opens more than
FD_SETSIZE (typically 1024) file descriptors, invoking those helpers
on a socket whose fd exceeded the limit wrote past the fd_set memory,
which is undefined behaviour and could corrupt the surrounding stack
frame.
