### PR TITLE
Fix TLS BIO partial write dropping data

### DIFF
--- a/src/tls_context.c
+++ b/src/tls_context.c
@@ -38,6 +38,7 @@
 // system
 #include <arpa/inet.h>
 #include <errno.h>
+#include <limits.h>
 #include <netinet/in.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>
@@ -144,13 +145,24 @@ static int write_bio_lua(lua_State *L, tls_ctx_t *ctx, const char *buf,
 {
     // drain first — pending SSL_write may have produced outgoing data that
     // needs to be sent before we can make progress with the new SSL_write
-
-    ssize_t rv = SSL_write(ctx->ssl, buf, (int)len);
+    int chunk  = (len > (size_t)INT_MAX) ? INT_MAX : (int)len;
+    ssize_t rv = SSL_write(ctx->ssl, buf, chunk);
     if (rv > 0) {
         // SSL_write always produces ciphertext in txbuf; signal the caller to
         // drain it so the data actually reaches the peer.
         lua_pushinteger(L, rv);
-        return 1;
+        if ((size_t)rv == len) {
+            // SSL_write always produces ciphertext in txbuf; signal the caller
+            // to drain it so the data actually reaches the peer.
+            return 1;
+        }
+        // Partial write (SSL_MODE_ENABLE_PARTIAL_WRITE): tell the caller
+        // how many bytes were consumed and that another write is required,
+        // so the wrapper resends the remainder just like the non-BIO
+        // write_lua path.
+        lua_pushnil(L);
+        lua_pushinteger(L, SSL_ERROR_WANT_WRITE);
+        return 3;
     }
 
     rv = SSL_get_error(ctx->ssl, (int)rv);

--- a/test/tls/stream/inet_test.lua
+++ b/test/tls/stream/inet_test.lua
@@ -514,3 +514,62 @@ function testcase.write_read_bio()
     s:close()
     assert(p:wait())
 end
+
+function testcase.write_read_bio_large_payload()
+    -- SSL_MODE_ENABLE_PARTIAL_WRITE is enabled on the client SSL_CTX, so a
+    -- plaintext payload larger than a single TLS record is delivered in
+    -- multiple SSL_write returns.  The client-side write wrapper must loop
+    -- on the "partial" indication until every byte reaches the peer.  A
+    -- 32 KiB payload spans two records and reliably exercises the partial
+    -- path without exhausting the SO_SNDBUF / SO_RCVBUF of the loopback
+    -- socket pair.
+    local host = '127.0.0.1'
+    local s = assert(inet.server.new(host, 0, {
+        reuseaddr = true,
+        reuseport = true,
+        tlscfg = {
+            cert = SERVER_CONFIG.cert,
+            key = SERVER_CONFIG.key,
+            use_bio = true,
+        },
+    }))
+    assert(s:listen())
+    local port = assert(s:getsockname()):port()
+    local msg = string.rep('X', 32 * 1024)
+
+    local p = fork()
+    if p:is_child() then
+        s:close()
+        local c = assert(inet.client.new(host, port, {
+            tlscfg = {
+                noverify_name = CLIENT_CONFIG.noverify_name,
+                noverify_time = CLIENT_CONFIG.noverify_time,
+                noverify_cert = CLIENT_CONFIG.noverify_cert,
+                use_bio = true,
+            },
+        }))
+        assert(c.tls_bio ~= nil, 'BIO not set on client')
+        assert(c:write(msg))
+        c:close()
+        return
+    end
+
+    local peer = assert(s:accept())
+    assert(peer.tls_bio ~= nil, 'BIO not set on server peer')
+
+    local buf = {}
+    local total = 0
+    while total < #msg do
+        local chunk = peer:read()
+        if not chunk then
+            break
+        end
+        buf[#buf + 1] = chunk
+        total = total + #chunk
+    end
+    peer:close()
+    s:close()
+    assert(p:wait())
+    assert.equal(total, #msg)
+    assert.equal(table.concat(buf), msg)
+end


### PR DESCRIPTION
write_bio_lua treated any positive SSL_write return as completed and
returned only the byte count.  With SSL_MODE_ENABLE_PARTIAL_WRITE
enabled on the client SSL_CTX, a plaintext payload larger than the
memory BIO's tx buffer produced a partial return that the Lua write
wrapper interpreted as "done", so the tail of the payload was
silently dropped before reaching the peer.
