### PR TITLE
Fix recvmsg silently accepting truncated cmsg

### DIFF
--- a/doc/net_socket.md
+++ b/doc/net_socket.md
@@ -389,6 +389,13 @@ receive a message along with optional ancillary data (cmsgs) from a socket.
   - `data:string?`: payload bytes (present only when `bufsize > 0`).
   - `cmsgs:table[]?`: array of cmsg descriptors, each `{ level = string,
     type = string, data = integer|string|integer[] }`.
+  - `flags:table`: `msg_flags` returned by `recvmsg(2)` as a set of
+    lowercase names.  A flag that is set on the returned `msghdr` appears
+    as `true` under its name (for example `trunc`, `ctrunc`, `eor`, `oob`,
+    `errqueue`, `cmsg_cloexec`); flags that are not set are omitted.
+    `ctrunc` in particular indicates that the kernel had to clip the
+    ancillary data because `cmsgbuf` was too small, so `cmsgs` may be
+    incomplete.
   - `addr:addrinfo?`: source [net.addrinfo](addrinfo.md) for datagram
     sockets (nil on connected sockets).
 - `err:error`: error object.

--- a/src/cmsghdr.c
+++ b/src/cmsghdr.c
@@ -232,8 +232,17 @@ int net_cmsg_build_buffer(lua_State *L, int idx)
  */
 static void push_data(lua_State *L, const struct cmsghdr *cmh)
 {
-    size_t datalen = cmh->cmsg_len -
-                     (size_t)((const char *)CMSG_DATA(cmh) - (const char *)cmh);
+    size_t hdrlen  = (size_t)((const char *)CMSG_DATA(cmh) - (const char *)cmh);
+    size_t datalen = 0;
+
+    // Guard against malformed cmsghdrs whose cmsg_len is smaller than the
+    // header itself; treat them as carrying no payload so the branches below
+    // do not read past the caller buffer.
+    if (cmh->cmsg_len < hdrlen) {
+        lua_pushliteral(L, "");
+        return;
+    }
+    datalen = cmh->cmsg_len - hdrlen;
 
     switch (cmh->cmsg_level) {
     case SOL_SOCKET:
@@ -251,6 +260,9 @@ PUSH_SOL_SOCKET:
     // Handle known SOL_SOCKET types with special representations.
     switch (cmh->cmsg_type) {
     case SCM_RIGHTS: {
+        // Round down to whole fds; the kernel may deliver a partial payload
+        // when the caller's control buffer was too small (MSG_CTRUNC), in
+        // which case datalen is not necessarily a multiple of sizeof(int).
         size_t nfd = datalen / sizeof(int);
         if (nfd == 1) {
             int fd;
@@ -276,6 +288,12 @@ PUSH_SOL_SOCKET:
         // { sec = <integer>, usec = <integer> } so that callers can access
         // the receive timestamp without decoding the raw bytes themselves.
         struct timeval tv;
+        if (datalen < sizeof(tv)) {
+            // Truncated ancillary data may leave SCM_TIMESTAMP shorter than
+            // struct timeval; return nil rather than reading past CMSG_DATA.
+            lua_pushnil(L);
+            return;
+        }
         memcpy(&tv, CMSG_DATA(cmh), sizeof(tv));
         lua_createtable(L, 0, 2);
         lua_pushinteger(L, (lua_Integer)tv.tv_sec);

--- a/src/constants.h
+++ b/src/constants.h
@@ -223,6 +223,35 @@ static const net_constant_t NET_MSGFLAG_MAP[] = {
     {NULL,           0               },
 };
 
+/*
+ * Names of MSG_* flags that may appear in the msghdr::msg_flags field
+ * returned by recvmsg(2).  The output map deliberately includes MSG_TRUNC
+ * that the input map above omits: the input ban only protects the
+ * caller-provided flag argument, whereas the kernel-set output field is
+ * meaningful and callers must be able to observe it.
+ */
+static const net_constant_t NET_MSGFLAG_OUTPUT_MAP[] = {
+#ifdef MSG_TRUNC
+    {"trunc",        MSG_TRUNC       },
+#endif
+#ifdef MSG_CTRUNC
+    {"ctrunc",       MSG_CTRUNC      },
+#endif
+#ifdef MSG_EOR
+    {"eor",          MSG_EOR         },
+#endif
+#ifdef MSG_OOB
+    {"oob",          MSG_OOB         },
+#endif
+#ifdef MSG_ERRQUEUE
+    {"errqueue",     MSG_ERRQUEUE    },
+#endif
+#ifdef MSG_CMSG_CLOEXEC
+    {"cmsg_cloexec", MSG_CMSG_CLOEXEC},
+#endif
+    {NULL,           0               },
+};
+
 static const net_constant_t NET_CMSG_LEVEL_MAP[] = {
     {"socket", SOL_SOCKET  },
     {"ip",     IPPROTO_IP  },

--- a/src/socket.c
+++ b/src/socket.c
@@ -1939,7 +1939,7 @@ static int recvmsg_lua(lua_State *L)
     }
 
     // Build the msg table on the Lua stack.
-    lua_createtable(L, 0, 3);
+    lua_createtable(L, 0, 4);
     if (bufsize > 0) {
         lua_pushlstring(L, databuf, (size_t)rv);
         lua_setfield(L, -2, "data");
@@ -1947,6 +1947,20 @@ static int recvmsg_lua(lua_State *L)
     if (net_cmsg_push_table(L, &data)) {
         lua_setfield(L, -2, "cmsgs");
     }
+
+    // Surface msg_flags so callers can detect kernel-side truncation and
+    // other status indicators.  Only the flags actually set on the returned
+    // msghdr appear in the subtable, keeping unset flags out of the way for
+    // callers that only care about a specific one.
+    lua_createtable(L, 0, 0);
+    for (const net_constant_t *entry = NET_MSGFLAG_OUTPUT_MAP; entry->name;
+         entry++) {
+        if ((data.msg_flags & entry->value) == entry->value) {
+            lua_pushboolean(L, 1);
+            lua_setfield(L, -2, entry->name);
+        }
+    }
+    lua_setfield(L, -2, "flags");
 
     if (data.msg_namelen > 0) {
         struct addrinfo ai = {

--- a/test/socket_test.lua
+++ b/test/socket_test.lua
@@ -3766,6 +3766,99 @@ function testcase.recvmsg_empty_input()
     b:close()
 end
 
+function testcase.recvmsg_reports_control_truncation()
+    -- When the kernel drops part of the ancillary data because the caller's
+    -- cmsg buffer was too small, it sets MSG_CTRUNC on msg_flags to warn
+    -- the caller not to trust the delivered cmsg set.  Expose that
+    -- indication through the returned msg table so callers can react
+    -- (for example by refusing to consume half of an SCM_RIGHTS batch).
+    local socks = assert(socket.pair({
+        socktype = 'stream',
+    }))
+    local a = socks[1]
+    local b = socks[2]
+
+    local path = os.tmpname()
+    local f = assert(io.open(path, 'w+'))
+
+    local len = assert(a:sendmsg('x', nil, {
+        {
+            level = 'socket',
+            type = 'rights',
+            data = {
+                fileno(f),
+                fileno(f),
+                fileno(f),
+                fileno(f),
+            },
+        },
+    }))
+    assert.equal(len, 1)
+
+    -- 8 bytes is smaller than any well-formed SCM_RIGHTS cmsg, so the
+    -- kernel truncates the ancillary data and sets MSG_CTRUNC.
+    local msg = assert(b:recvmsg(1, 8))
+    assert.equal(msg.data, 'x')
+    assert(msg.flags, 'recvmsg must report msg_flags')
+    assert.is_true(msg.flags.ctrunc)
+    -- Any file descriptors that the kernel did deliver despite truncation
+    -- must still be closed to avoid leaking.
+    if msg.cmsgs then
+        for _, cm in ipairs(msg.cmsgs) do
+            if cm.type == 'rights' then
+                if type(cm.data) == 'number' then
+                    socket.close(cm.data)
+                else
+                    for _, fd in ipairs(cm.data) do
+                        socket.close(fd)
+                    end
+                end
+            end
+        end
+    end
+
+    f:close()
+    os.remove(path)
+    a:close()
+    b:close()
+end
+
+function testcase.recvmsg_reports_no_truncation_when_buffers_fit()
+    -- The complement of recvmsg_reports_control_truncation: with cmsg
+    -- buffers large enough to receive the full ancillary data, msg.flags
+    -- reports both truncated and ctruncated as false.
+    local socks = assert(socket.pair({
+        socktype = 'stream',
+    }))
+    local a = socks[1]
+    local b = socks[2]
+
+    local path = os.tmpname()
+    local f = assert(io.open(path, 'w+'))
+
+    assert(a:sendmsg('y', nil, {
+        {
+            level = 'socket',
+            type = 'rights',
+            data = fileno(f),
+        },
+    }))
+
+    local msg = assert(b:recvmsg(1, 128))
+    assert.equal(msg.data, 'y')
+    assert(msg.flags, 'recvmsg must report msg_flags')
+    -- No truncation flags should be present on the returned table.
+    assert.is_nil(msg.flags.trunc)
+    assert.is_nil(msg.flags.ctrunc)
+    assert.equal(#msg.cmsgs, 1)
+    socket.close(msg.cmsgs[1].data)
+
+    f:close()
+    os.remove(path)
+    a:close()
+    b:close()
+end
+
 function testcase.recvmsg_oom()
     -- Lua VMs reject impractically large userdata allocations with
     -- implementation-specific messages; verify that both buffer arguments


### PR DESCRIPTION
recvmsg_lua exposed only data / cmsgs / addr, so a peer's ancillary
data was consumed as complete even when the kernel had set
MSG_CTRUNC to warn that it had clipped the cmsg set.  A malformed
cmsg_len shorter than the header could also underflow the payload
length, and SCM_TIMESTAMP shorter than struct timeval could read
past the caller buffer.
