### PR TITLE
Fix TLS sendfile over-reading and stale error return

### DIFF
--- a/lib/tls/stream.lua
+++ b/lib/tls/stream.lua
@@ -51,7 +51,7 @@ end
 
 --- sendfile
 --- @param f file*|integer|string
---- @param bytes integer
+--- @param bytes integer?
 --- @param offset? integer
 --- @return integer? len
 --- @return any err
@@ -62,30 +62,32 @@ function Socket:sendfile(f, bytes, offset)
         return nil, errorf('failed to tofile()', err)
     end
 
+    if offset == nil then
+        offset = 0
+    elseif not is_uint(offset) then
+        return nil, new_errno('EINVAL', 'offset must be an nil or uint')
+    end
+
     if bytes == nil then
-        -- send all content of the file
+        -- send remaining content starting at offset; without subtracting the
+        -- offset, sendfile(f, nil, N>0) would try to transfer stat.size
+        -- bytes and drive pread past EOF.
         local stat
         stat, err = fstat(file)
         if not stat then
             return nil, err
         end
-        bytes = stat.size
+
+        -- calculate remaining bytes to send
+        bytes = stat.size - offset
+        if bytes <= 0 then
+            return 0
+        end
     elseif not is_uint(bytes) then
         return nil, new_errno('EINVAL', 'bytes must be an nil or uint')
     elseif bytes <= 0 then
         -- nothing to send
         return 0
-    end
-
-    if offset == nil then
-        offset = 0
-    end
-
-    if offset == nil then
-        -- send from the current position of the file
-        offset = file:seek('cur')
-    elseif not is_uint(offset) then
-        return nil, new_errno('EINVAL', 'offset must be an nil or uint')
     end
 
     local bufsiz
@@ -107,6 +109,11 @@ function Socket:sendfile(f, bytes, offset)
             s, err = pread(file, nread, offset + sent)
             if not s then
                 return sent, err
+            elseif #s == 0 then
+                -- reached end-of-file before satisfying the requested byte
+                -- count; return what has been sent rather than spinning on
+                -- a pread that keeps returning the empty string.
+                return sent
             end
             data = data .. s
         end
@@ -119,7 +126,7 @@ function Socket:sendfile(f, bytes, offset)
         end
 
         if serr then
-            return sent, err
+            return sent, serr
         elseif timeout then
             return sent, nil, timeout
         end

--- a/test/tls/stream/inet_test.lua
+++ b/test/tls/stream/inet_test.lua
@@ -317,6 +317,105 @@ function testcase.sendfile_recv()
     s:close()
 end
 
+function testcase.sendfile_recv_with_offset_nil_bytes()
+    -- Regression: sendfile(f, nil, offset>0) must transfer only the bytes
+    -- from `offset` to end-of-file.  A previous implementation used
+    -- stat.size directly and drove pread past EOF for offset > 0.
+    local f = assert(io.open(TESTFILE, 'w+'))
+    local msg = 'hello world - sendfile offset nil bytes regression'
+    assert(f:write(msg))
+    assert(f:flush())
+    local offset = 6 -- skip "hello "
+    local expected = msg:sub(offset + 1)
+
+    local host = '127.0.0.1'
+    local s = assert(inet.server.new(host, 0, {
+        reuseaddr = true,
+        reuseport = true,
+        tlscfg = SERVER_CONFIG,
+    }))
+    assert(s:listen())
+    local port = assert(s:getsockname()):port()
+
+    local p = fork()
+    if p:is_child() then
+        s:close()
+        local c = assert(inet.client.new(host, port, {
+            tlscfg = CLIENT_CONFIG,
+        }))
+        assert(c:sendfile(f, nil, offset))
+        -- wait for peer to close before shutting down TLS
+        c:read()
+        c:close()
+        return
+    end
+
+    local peer = assert(s:accept())
+    local total = 0
+    local chunks = {}
+    while total < #expected do
+        local data = assert(peer:recv())
+        total = total + #data
+        chunks[#chunks + 1] = data
+    end
+    assert.equal(total, #expected)
+    assert.equal(table.concat(chunks), expected)
+
+    peer:close()
+    s:close()
+    f:close()
+    assert(p:wait())
+end
+
+function testcase.sendfile_stops_at_eof()
+    -- Regression: sendfile(f, bytes, offset) with bytes larger than the
+    -- remaining file must not spin on pread returning the empty string.
+    -- The wrapper stops at EOF and reports what it managed to transfer.
+    local f = assert(io.open(TESTFILE, 'w+'))
+    local msg = 'short'
+    assert(f:write(msg))
+    assert(f:flush())
+
+    local host = '127.0.0.1'
+    local s = assert(inet.server.new(host, 0, {
+        reuseaddr = true,
+        reuseport = true,
+        tlscfg = SERVER_CONFIG,
+    }))
+    assert(s:listen())
+    local port = assert(s:getsockname()):port()
+
+    local p = fork()
+    if p:is_child() then
+        s:close()
+        local c = assert(inet.client.new(host, port, {
+            tlscfg = CLIENT_CONFIG,
+        }))
+        -- Request many more bytes than the file actually has.
+        local n = assert(c:sendfile(f, 4096, 0))
+        assert(n <= #msg,
+               'sendfile must not report more bytes than the file holds')
+        c:read()
+        c:close()
+        return
+    end
+
+    local peer = assert(s:accept())
+    local total = 0
+    local chunks = {}
+    while total < #msg do
+        local data = assert(peer:recv())
+        total = total + #data
+        chunks[#chunks + 1] = data
+    end
+    assert.equal(table.concat(chunks), msg)
+
+    peer:close()
+    s:close()
+    f:close()
+    assert(p:wait())
+end
+
 function testcase.sendmsg_recvmsg()
     local host = '127.0.0.1'
     local s = assert(inet.server.new(host, 0, {


### PR DESCRIPTION
Socket:sendfile treated a nil `bytes` argument as "send all of
stat.size" regardless of `offset`, so sendfile(f, nil, N>0) requested
more bytes than the file held past `offset` and drove pread beyond
end-of-file.  A dead second `if offset == nil` branch also made the
"send from current position" comment unreachable, and the send-error
path returned the stale `err` captured before the send instead of the
`serr` returned by it, hiding TLS-side errors behind whatever earlier
pread or fstat had left in scope.
