### PR TITLE
Fix connect() confusing EALREADY with EISCONN

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -2071,16 +2071,19 @@ static int connect_lua(lua_State *L)
     net_addrinfo_t *info = lauxh_checkudata(L, 2, NET_ADDRINFO_MT);
 
     if (connect(s->fd, info->ai.ai_addr, info->ai.ai_addrlen) == 0 ||
-        errno == EALREADY) {
-        // connect completed synchronously, or a previous non-blocking
-        // connect() attempt is still in progress; either way the socket is
-        // owned by the kernel and the caller only needs to wait for I/O
-        // readiness to finish the handshake.
+        errno == EISCONN) {
+        // connect completed synchronously, or the socket is already
+        // connected (EISCONN from a prior non-blocking connect() that has
+        // since finished).  In both cases the caller can proceed without
+        // waiting for I/O readiness.
         lua_pushboolean(L, 1);
         return 1;
-    } else if (errno == EINPROGRESS) {
-        // non-blocking connect started; the caller should wait for the
-        // socket to become writable before checking SO_ERROR.
+    } else if (errno == EINPROGRESS || errno == EALREADY) {
+        // EINPROGRESS: a non-blocking connect has just started.
+        // EALREADY:    a previously-started non-blocking connect() is still
+        //              in progress on this socket.
+        // In both cases the caller should wait for the socket to become
+        // writable and then check SO_ERROR to determine the outcome.
         lua_pushboolean(L, 0);
         lua_pushnil(L);
         lua_pushboolean(L, 1);

--- a/test/socket_test.lua
+++ b/test/socket_test.lua
@@ -1,5 +1,6 @@
 local fileno = require('io.fileno')
 local testcase = require('testcase')
+local timer = require('testcase.timer')
 local assert = require('assert')
 local errno = require('errno')
 local addrinfo = require('net.addrinfo')
@@ -4097,6 +4098,110 @@ function testcase.connect()
     assert(err)
 end
 
+function testcase.connect_returns_again_when_previous_connect_pending()
+    -- While a non-blocking connect() is still in progress on a socket,
+    -- invoking connect() on the same socket surfaces EALREADY.  connect_lua
+    -- must treat EALREADY the same as EINPROGRESS -- that is, "still in
+    -- progress" -- and return (false, nil, true).  Prior to the fix,
+    -- EALREADY was collapsed into the success path and the second call
+    -- returned (true), which would let callers proceed on an unhandshaked
+    -- fd.
+    --
+    -- The pending state is produced deterministically by targeting an
+    -- address in the TEST-NET-1 range (RFC 5737, 192.0.2.0/24), which is
+    -- reserved for documentation and is not answered by any real host.
+    -- The SYN is transmitted but never receives a SYN-ACK, so successive
+    -- connect() calls on the same fd all observe the same in-progress
+    -- state without racing against a real handshake.
+    local ai = assert(addrinfo.inet('192.0.2.1', 8080, {
+        socktype = 'stream',
+        protocol = 'tcp',
+    }))
+    local c = assert(socket.new_inet({
+        socktype = 'stream',
+        protocol = 'tcp',
+    }))
+
+    -- First connect() on a non-blocking socket returns EINPROGRESS as
+    -- (false, nil, true).
+    local ok, err, again = c:connect(ai)
+    assert.is_nil(err)
+    assert.is_false(ok)
+    assert.is_true(again)
+
+    -- Second connect() on the same socket returns EALREADY as
+    -- (false, nil, true).
+    ok, err, again = c:connect(ai)
+    assert.is_nil(err)
+    assert.is_false(ok)
+    assert.is_true(again)
+    c:close()
+
+    -- socket.connect_inet() also drives connect_lua and observes the same
+    -- shape from its internal call: it returns (sock, nil, true) when the
+    -- initial connect() surfaces EINPROGRESS.
+    c, err, again = assert(socket.connect_inet(ai, {
+        socktype = 'stream',
+        protocol = 'tcp',
+    }))
+    assert.is_nil(err)
+    assert.is_true(again)
+
+    -- A follow-up connect() on the still-pending socket again returns
+    -- EALREADY as (false, nil, true).
+    ok, err, again = c:connect(ai)
+    assert.is_nil(err)
+    assert.is_false(ok)
+    assert.is_true(again)
+    c:close()
+end
+
+function testcase.connect_returns_ok_when_already_connected()
+    -- Once the three-way handshake has finished, calling connect() again on
+    -- the same socket causes the kernel to fail with EISCONN.  connect_lua
+    -- must treat EISCONN as success (already connected) and return
+    -- (true), rather than surfacing the errno as a terminal error.  Prior
+    -- to the fix, EISCONN fell through to the error path and the second
+    -- connect() returned (false, err).
+    local server = assert(socket.bind_inet('127.0.0.1', 0, {
+        socktype = 'stream',
+        protocol = 'tcp',
+        reuseaddr = true,
+    }))
+    assert(server:listen(32))
+    local ai = assert(server:getsockname())
+    local ai_client = assert(addrinfo.inet('127.0.0.1', ai:port(), {
+        socktype = 'stream',
+        protocol = 'tcp',
+    }))
+    local c = assert(socket.new_inet({
+        socktype = 'stream',
+        protocol = 'tcp',
+    }))
+
+    -- First connect() on a non-blocking socket returns EINPROGRESS as
+    -- (false, nil, true).
+    local ok, err, again = c:connect(ai_client)
+    assert.is_false(ok)
+    assert.is_nil(err)
+    assert.is_true(again)
+
+    -- Give the kernel time to complete the three-way handshake on
+    -- loopback.  100 ms is well above the observed handshake latency and
+    -- keeps the test time-bounded.
+    timer.sleep(0.1)
+
+    -- Second connect() on the now-connected socket surfaces EISCONN,
+    -- which connect_lua must report as (true, nil, nil).
+    ok, err, again = c:connect(ai_client)
+    assert.is_true(ok)
+    assert.is_nil(err)
+    assert.is_nil(again)
+
+    c:close()
+    server:close()
+end
+
 function testcase.listen()
     -- listen() marks a bound socket as accepting incoming connections.
     local s = assert(socket.bind_inet('127.0.0.1', 0, {
@@ -4571,7 +4676,7 @@ function testcase.sendable_recvable_supports_high_fd_values()
     -- hoard and silently skips the assertion so it does not perturb
     -- constrained CI environments.
     local target = 1030
-    local hoard  = {}
+    local hoard = {}
     local a, b
     while true do
         local socks = socket.pair({


### PR DESCRIPTION
## Summary

`socket:connect()` interpreted `EALREADY` as a synchronous success and
reported `(true)`, but that errno actually means a previously-issued
non-blocking `connect()` on the same socket is still in progress.
Callers therefore proceeded with an unhandshaked fd and either dropped
data or raced against the eventual `SO_ERROR` report.

At the same time, `EISCONN` (returned when the socket is already
connected) fell through to the terminal error branch, so a follow-up
`connect()` on an already-connected socket was reported as an error
rather than a success.

## Changes

- `src/socket.c`: move `EALREADY` to the same "still in progress"
  branch as `EINPROGRESS` (returns `(false, nil, true)`), and route
  `EISCONN` to the success branch (returns `(true)`).  Comments on
  both branches are rewritten to describe the actual errno semantics.

## Tests

Two deterministic tests are added in `test/socket_test.lua`:

- `connect_returns_again_when_previous_connect_pending` targets an
  address in the TEST-NET-1 range (RFC 5737, `192.0.2.0/24`) that
  never answers the SYN, so successive `connect()` calls observe
  `EINPROGRESS` / `EALREADY` deterministically and are asserted to
  return `(false, nil, true)`.  The same shape is verified through
  `socket.connect_inet()` as well.
- `connect_returns_ok_when_already_connected` establishes a real
  loopback connection, waits 100 ms for the kernel to complete the
  handshake, and asserts that a follow-up `connect()` returns
  `(true, nil, nil)` for the `EISCONN` branch.

Both tests fail on the pre-fix code and pass after the fix.  The full
`testcase test/` suite (351 tests) passes three times in a row.

## Compatibility

Behaviour change for existing callers that relied on `EALREADY` being
silently swallowed as success: they will now see `(false, nil, true)`
and must wait for the socket to become writable before checking
`SO_ERROR`, matching the existing `EINPROGRESS` contract.  Callers
that already handle the `again` flag are unaffected.
