### PR TITLE
Fix closefd losing the shutdown errno

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -1073,8 +1073,17 @@ static inline int closefd(lua_State *L, int fd, int how, int with_shutdown)
 
     if (close(fd) == 0) {
         if (err) {
+            // close(2) succeeded but shutdown(2) had failed; report the
+            // shutdown errno we captured earlier rather than reading `errno`
+            // fresh here.  POSIX allows a successful close(2) to leave the
+            // thread-local `errno` untouched, so on most platforms `errno`
+            // still equals `err`, but relying on that leak-through is
+            // brittle: any future refactor that adds a syscall (or a
+            // library call which touches errno) between shutdown() and this
+            // line would silently start reporting an unrelated errno as the
+            // shutdown failure.
             lua_pushboolean(L, 0);
-            lua_errno_new(L, errno, "shutdown");
+            lua_errno_new(L, err, "shutdown");
             return 2;
         }
     } else if (err) {

--- a/test/socket_test.lua
+++ b/test/socket_test.lua
@@ -4338,33 +4338,56 @@ function testcase.unwrap_returns_fd_and_disables_socket()
 end
 
 function testcase.close_shutdown_and_close_both_fail()
-    -- socket.close(fd, how) calls shutdown() then close().  A stale (already
-    -- closed) fd causes both to fail with EBADF, exercising the
-    -- "shutdown + close both failed" branch of closefd_lua.
+    -- socket.close(fd, how) calls shutdown() then close().  When the fd has
+    -- already been closed, both syscalls fail with EBADF and closefd() must
+    -- surface the chained error: the top-level error carries the close(2)
+    -- failure and its `wrap` field carries the shutdown(2) failure.  A
+    -- previous assertion of just `assert(err)` accepted any truthy value and
+    -- would not have detected a regression that dropped the chained
+    -- shutdown error or mislabelled either op.
     local s = assert(socket.new_inet({
         socktype = 'stream',
         protocol = 'tcp',
     }))
     local fd = s:fd()
     assert(socket.close(fd))
+
     local ok, err = socket.close(fd, 'rd')
     assert.is_false(ok)
-    assert(err)
+    assert(err, 'closefd() must return an error object when both syscalls fail')
+    assert.equal(err.op, 'close')
+    assert.equal(err.type, errno.EBADF)
+    assert(err.wrap,
+           'closefd() must attach the shutdown failure to err.wrap when both fail')
+    assert.equal(err.wrap.op, 'shutdown')
+    assert.equal(err.wrap.type, errno.EBADF)
 end
 
 function testcase.close_with_shutdown_error()
     -- socket.close(fd, how) performs shutdown(how) followed by close(fd).
-    -- The success path (shutdown may fail with ENOTCONN because the socket
-    -- was never connected, but the subsequent close() succeeds) still
-    -- returns non-nil via the closefd() helper.  This exercises the
-    -- "shutdown fails, close succeeds" branch.
+    -- shutdown(2) on a socket that has never been connected fails with
+    -- ENOTCONN, but close(2) still succeeds; closefd() must therefore return
+    -- (false, ENOTCONN-from-shutdown), NOT the errno that happens to remain
+    -- in the thread after close(2) returned successfully.
+    --
+    -- The previous assertion `assert(rv or err)` was trivially satisfied by
+    -- the non-nil error alone and did not verify that the reported errno
+    -- was the one shutdown(2) had recorded.  This regression asserts on the
+    -- concrete type / op so a future refactor cannot silently swap the
+    -- reported errno for whatever value happened to sit in `errno` after
+    -- close(2).
     local closed = assert(socket.bind_inet('127.0.0.1', 0, {
         socktype = 'stream',
         protocol = 'tcp',
     }))
     local fd = closed:unwrap()
+
     local rv, err = socket.close(fd, 'rd')
-    assert(rv or err)
+    assert.is_false(rv)
+    assert(err, 'closefd() must return an error when shutdown(2) fails')
+    assert.equal(err.op, 'shutdown')
+    assert.equal(err.type, errno.ENOTCONN)
+    assert.is_nil(err.wrap)
 end
 
 function testcase.shutdown_invalid_flags()


### PR DESCRIPTION
closefd() passed the live errno to lua_errno_new() when close()
succeeded, so the shutdown errno saved earlier was never returned.
