### PR TITLE
Fix gcthread reading the gc error from the wrong lua_State

### DIFF
--- a/src/gcthread.c
+++ b/src/gcthread.c
@@ -201,7 +201,7 @@ void net_gcthread_close(lua_State *L, net_socket_t *s)
             // Release build: report to stderr; raising here would allocate new
             // Lua objects and can crash LuaJIT during lua_close finalization.
             fprintf(stderr, "net.socket: gc callback error: %s\n",
-                    lua_tostring(L, -1));
+                    lua_tostring(s->gc_thread, -1));
 #endif
             lua_pop(s->gc_thread, 1);
         }


### PR DESCRIPTION
net_gcthread_close() read the gc callback error from the parent
lua_State, but lua_pcall had left the error object on s->gc_thread;
release builds therefore printed (null) instead of the message.
