### PR TITLE
Fix ocsp_verify_cb leaking a peer certificate reference

### DIFF
--- a/src/tls_client.c
+++ b/src/tls_client.c
@@ -333,6 +333,12 @@ static int ocsp_verify_cb(SSL *ssl, void *arg)
     if (ctx.resp) {
         OCSP_RESPONSE_free(ctx.resp);
     }
+    if (ctx.cert) {
+        // SSL_get_peer_certificate() bumps the peer certificate's refcount,
+        // so release it here to avoid leaking a reference on every stapled
+        // OCSP verification.
+        X509_free(ctx.cert);
+    }
 
     return rc;
 }


### PR DESCRIPTION
ocsp_verify_cb() obtained the peer certificate through
SSL_get_peer_certificate() but never called X509_free() to release
the extra reference; every stapled OCSP verification leaked one.
