### PR TITLE
Fix set_crls passing zero length to BIO_new_mem_buf

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,8 @@ jobs:
         luarocks install exec
         luarocks install io-fileno
         luarocks install io-wait
+        luarocks install mkdir
+        luarocks install rmdir
     -
       name: Run Test
       run: |

--- a/src/tls_client.c
+++ b/src/tls_client.c
@@ -38,6 +38,7 @@
 #include <openssl/x509.h>
 #include <openssl/x509_vfy.h>
 #include <openssl/x509v3.h>
+#include <limits.h>
 #include <stdio.h>
 
 // set callback for ALPN (Application-Layer Protocol Negotiation) support
@@ -49,13 +50,21 @@ static int set_crls(lua_State *L)
 {
     tls_client_t *c          = luaL_checkudata(L, 1, NET_TLS_CLIENT_MT);
     size_t len               = 0;
-    const char *crls         = luaL_checkstring(L, 2);
+    const char *crls         = luaL_checklstring(L, 2, &len);
     X509_STORE *store        = SSL_CTX_get_cert_store(c->ctx);
-    BIO *bio                 = BIO_new_mem_buf((void *)crls, len);
+    BIO *bio                 = NULL;
     STACK_OF(X509_INFO) *inf = NULL;
     const char *errop        = NULL;
     const char *errmsg       = NULL;
 
+    // BIO_new_mem_buf takes int; refuse >INT_MAX to prevent truncation.
+    // Not exercised by tests: allocating a 2GB PEM in CI is impractical.
+    if (len > INT_MAX) {
+        errop  = "BIO_new_mem_buf";
+        errmsg = "CRL PEM buffer exceeds INT_MAX";
+        goto FAIL;
+    }
+    bio = BIO_new_mem_buf((void *)crls, (int)len);
     if (!bio) {
         errop  = "BIO_new_mem_buf";
         errmsg = "failed to create BIO";
@@ -70,7 +79,10 @@ static int set_crls(lua_State *L)
         goto FAIL;
     }
 
-    // add CRLs to the store
+    // Add CRLs to the store.  X509_STORE_add_crl's failure branch is not
+    // covered from Lua: OpenSSL 3.x accepts duplicates, and other triggers
+    // (internal malloc failure, specially crafted CRLs) are not reachable
+    // from userspace.
     for (int i = 0; i < sk_X509_INFO_num(inf); i++) {
         X509_INFO *it = sk_X509_INFO_value(inf, i);
         if (!it->crl) {

--- a/test/tls/context_test.lua
+++ b/test/tls/context_test.lua
@@ -2,6 +2,8 @@ require('luacov')
 local testcase = require('testcase')
 local assert = require('assert')
 local exec = require('exec').execvp
+local mkdir = require('mkdir')
+local rmdir = require('rmdir')
 local socket = require('net.socket')
 local gpoll = require('gpoll')
 local sleep = require('time.sleep')
@@ -10,6 +12,8 @@ local new_tls_server = require('net.tls.server')
 local new_tls_client = require('net.tls.client')
 
 local SERVER_CONFIG
+local CRL_FIXTURE_DIR
+local CRL_FIXTURE_PEM
 
 -- per-operation I/O timeout (seconds); each WANT wait may take up to this long.
 local DEADLINE = 10
@@ -45,11 +49,93 @@ function testcase.before_all()
         cert = 'cert.pem',
         key = 'cert.key',
     }
+
+    -- CRL fixture: build a throwaway openssl CA + empty CRL in a temp dir.
+    -- CRL_FIXTURE_PEM feeds the set_crls testcase; after_all uses rmdir(2).
+    CRL_FIXTURE_DIR = os.tmpname()
+    os.remove(CRL_FIXTURE_DIR)
+    assert(mkdir(CRL_FIXTURE_DIR, '0700', true))
+
+    local cnf_path = CRL_FIXTURE_DIR .. '/ca.cnf'
+    local cnf = assert(io.open(cnf_path, 'w'))
+    cnf:write(([[
+[ ca ]
+default_ca = CA_default
+[ CA_default ]
+database = %s/index.txt
+serial = %s/serial
+crlnumber = %s/crlnumber
+certificate = %s/ca.crt
+private_key = %s/ca.key
+default_md = sha256
+default_crl_days = 30
+policy = policy_any
+[ policy_any ]
+commonName = supplied
+]]):format(CRL_FIXTURE_DIR, CRL_FIXTURE_DIR, CRL_FIXTURE_DIR,
+           CRL_FIXTURE_DIR, CRL_FIXTURE_DIR))
+    cnf:close()
+
+    assert(io.open(CRL_FIXTURE_DIR .. '/index.txt', 'w')):close()
+    local serial = assert(io.open(CRL_FIXTURE_DIR .. '/serial', 'w'))
+    serial:write('1000\n')
+    serial:close()
+    local crlnum = assert(io.open(CRL_FIXTURE_DIR .. '/crlnumber', 'w'))
+    crlnum:write('1000\n')
+    crlnum:close()
+
+    local ca = assert(exec('openssl', {
+        'req',
+        '-x509',
+        '-newkey',
+        'rsa:2048',
+        '-nodes',
+        '-days',
+        '1',
+        '-keyout',
+        CRL_FIXTURE_DIR .. '/ca.key',
+        '-out',
+        CRL_FIXTURE_DIR .. '/ca.crt',
+        '-config',
+        cnf_path,
+        '-subj',
+        '/CN=TestCRL',
+    }))
+    for _ in ca.stderr:lines() do
+    end
+    local ca_res = assert(ca:close())
+    if ca_res.exit ~= 0 then
+        error('failed to generate CA cert for CRL fixture')
+    end
+
+    local gencrl = assert(exec('openssl', {
+        'ca',
+        '-config',
+        cnf_path,
+        '-gencrl',
+        '-out',
+        CRL_FIXTURE_DIR .. '/ca.crl',
+    }))
+    for _ in gencrl.stderr:lines() do
+    end
+    local gencrl_res = assert(gencrl:close())
+    if gencrl_res.exit ~= 0 then
+        error('failed to generate CRL for CRL fixture')
+    end
+
+    local crl = assert(io.open(CRL_FIXTURE_DIR .. '/ca.crl', 'r'))
+    CRL_FIXTURE_PEM = crl:read('*a')
+    crl:close()
 end
 
 function testcase.after_all()
     os.remove('cert.pem')
     os.remove('cert.key')
+    if CRL_FIXTURE_DIR then
+        assert(rmdir(CRL_FIXTURE_DIR, true))
+        CRL_FIXTURE_DIR = nil
+        CRL_FIXTURE_PEM = nil
+    end
 end
 
 function testcase.encrypted_length()
@@ -676,4 +762,36 @@ function testcase.connect_accepts_no_servername_when_hostname_verify_disabled()
     if not ok then
         error(err)
     end
+end
+
+--- set_crls: verifies that a valid PEM CRL is accepted (regression against
+--- the length-zero bug in luaL_checkstring) and that non-string arguments
+--- are rejected by luaL_checklstring before any BIO allocation.  Confirming
+--- that the CRL was actually added to the X509_STORE requires internal
+--- inspection or a handshake against a revoked cert, both out of scope.
+function testcase.set_crls()
+    assert(CRL_FIXTURE_PEM and #CRL_FIXTURE_PEM > 0,
+           'CRL fixture must be prepared by before_all')
+    local client = assert(new_tls_client())
+
+    -- valid PEM CRL: after the fix, BIO_new_mem_buf sees the full stream.
+    local ok, err = client:set_crls(CRL_FIXTURE_PEM)
+    assert.is_true(ok, err and tostring(err) or 'set_crls returned falsy')
+    assert.is_nil(err)
+
+    -- non-string arguments raise a Lua type error.  Numbers are accepted
+    -- because luaL_checklstring converts them implicitly.
+    for _, bad in ipairs({
+        {},
+        true,
+    }) do
+        local terr = assert.throws(function()
+            client:set_crls(bad)
+        end)
+        assert.match(terr, 'string expected', false)
+    end
+    local nerr = assert.throws(function()
+        client:set_crls()
+    end)
+    assert.match(nerr, 'string expected', false)
 end


### PR DESCRIPTION
set_crls read the CRL with luaL_checkstring, which does not report
the string length, so BIO_new_mem_buf received a zero-length buffer
and every CRL was silently ignored.
