### PR TITLE
Fix tls_bio_new double free on BUF_MEM_grow failure

### DIFF
--- a/src/tls_bio.c
+++ b/src/tls_bio.c
@@ -438,11 +438,11 @@ static inline int bio_buf_init(tls_bio_buf_t *b, int cap)
 {
     b->mem = BUF_MEM_new();
     if (!b->mem) {
-        // failed to allocate BUF_MEM
         return -1;
     } else if (BUF_MEM_grow(b->mem, cap) == 0) {
-        // error occurred during buffer allocation
+        // grow failed: free and NULL so callers do not double-free.
         BUF_MEM_free(b->mem);
+        b->mem = NULL;
         return -1;
     }
     zring_init(&b->buf, b->mem->data, cap);
@@ -453,12 +453,16 @@ tls_bio_t *tls_bio_new(lua_State *L, int fd, int cap)
 {
     tls_bio_t *bio = lua_newuserdata(L, sizeof(tls_bio_t));
 
-    bio->fd  = fd;
-    bio->ref = LUA_NOREF;
+    bio->fd     = fd;
+    bio->ref    = LUA_NOREF;
+    bio->rx.mem = NULL;
+    bio->tx.mem = NULL;
     if (bio_buf_init(&bio->rx, cap) != 0 || bio_buf_init(&bio->tx, cap) != 0) {
+        // bio_buf_init NULLs its own mem on failure, so only the rx side
+        // (if it succeeded before tx failed) needs releasing here.
         if (bio->rx.mem) {
-            // error occurred during buffer allocation
             BUF_MEM_free(bio->rx.mem);
+            bio->rx.mem = NULL;
         }
         return NULL;
     }

--- a/test/tls/context_test.lua
+++ b/test/tls/context_test.lua
@@ -72,8 +72,8 @@ default_crl_days = 30
 policy = policy_any
 [ policy_any ]
 commonName = supplied
-]]):format(CRL_FIXTURE_DIR, CRL_FIXTURE_DIR, CRL_FIXTURE_DIR,
-           CRL_FIXTURE_DIR, CRL_FIXTURE_DIR))
+]]):format(CRL_FIXTURE_DIR, CRL_FIXTURE_DIR, CRL_FIXTURE_DIR, CRL_FIXTURE_DIR,
+           CRL_FIXTURE_DIR))
     cnf:close()
 
     assert(io.open(CRL_FIXTURE_DIR .. '/index.txt', 'w')):close()
@@ -794,4 +794,21 @@ function testcase.set_crls()
         client:set_crls()
     end)
     assert.match(nerr, 'string expected', false)
+end
+
+--- connect_bio_bufcap_too_large: an unreasonably large bufcap makes
+--- BUF_MEM_grow fail inside bio_buf_init.  After the fix the failure path
+--- releases each side independently and returns (nil, error); before the
+--- fix the same code aborted with a double free.
+function testcase.connect_bio_bufcap_too_large()
+    local sp = assert(socket.pair({
+        socktype = 'stream',
+    }))
+    local client = assert(new_tls_client())
+    local ctx, err = tls_context.connect(client, sp[1]:fd(), nil, true, false,
+                                         true, true, 2147483000)
+    assert.is_nil(ctx)
+    assert(err, 'connect must surface the bio_buf_init failure')
+    sp[1]:close()
+    sp[2]:close()
 end


### PR DESCRIPTION
bio_buf_init freed BUF_MEM on grow failure but left b->mem pointing
to the freed block, so tls_bio_new's cleanup path freed it a second
time and aborted the process on any bufcap large enough to fail
BUF_MEM_grow.
