### PR TITLE
Fix AF_UNIX addr() overrunning sun_path via strlen

### DIFF
--- a/src/addrinfo.c
+++ b/src/addrinfo.c
@@ -274,7 +274,30 @@ static int addr_lua(lua_State *L)
 
     case AF_UNIX: {
         struct sockaddr_un *addr = (struct sockaddr_un *)info->ai.ai_addr;
-        lua_pushstring(L, addr->sun_path);
+        size_t off               = offsetof(struct sockaddr_un, sun_path);
+        size_t len               = 0;
+
+        if (info->ai.ai_addrlen <= off) {
+            // unnamed socket: no sun_path bytes.
+            lua_pushliteral(L, "");
+            break;
+        }
+
+        len = info->ai.ai_addrlen - off;
+        if (len > sizeof(addr->sun_path)) {
+            len = sizeof(addr->sun_path);
+        }
+
+#ifdef __linux__
+        // Linux abstract socket: name may contain NULs, treat as binary.
+        if (addr->sun_path[0] == '\0') {
+            lua_pushlstring(L, addr->sun_path, len);
+            break;
+        }
+#endif
+        // pathname: NUL is optional; strnlen bounds the read to ai_addrlen.
+        len = strnlen(addr->sun_path, len);
+        lua_pushlstring(L, addr->sun_path, len);
     } break;
 
     // unsupported family

--- a/src/addrinfo.h
+++ b/src/addrinfo.h
@@ -72,6 +72,18 @@ static inline net_addrinfo_t *net_addrinfo_new(lua_State *L,
     info->ai.ai_addr  = lua_newuserdata(L, sizeof(struct sockaddr_storage));
     info->ai_addr_ref = lauxh_ref(L);
 
+    // Validate before memcpy so an oversized ai_addrlen cannot spill past
+    // sockaddr_storage; zero the userdata to keep uninitialised bytes past
+    // ai_addrlen deterministic instead of leaking Lua-managed memory into
+    // downstream reads (e.g. addr()'s sun_path traversal).
+    if (!src->ai_addr || src->ai_addrlen > sizeof(struct sockaddr_storage)) {
+        luaL_error(L,
+                   "net_addrinfo_new: ai_addrlen (%d) exceeds "
+                   "sockaddr_storage (%d)",
+                   (int)src->ai_addrlen, (int)sizeof(struct sockaddr_storage));
+    }
+    memset((void *)info->ai.ai_addr, 0, sizeof(struct sockaddr_storage));
+
     // copy sockaddr data
     info->ai.ai_addrlen = src->ai_addrlen;
     memcpy((void *)info->ai.ai_addr, (void *)src->ai_addr, src->ai_addrlen);

--- a/test/addrinfo_test.lua
+++ b/test/addrinfo_test.lua
@@ -3,12 +3,25 @@ local testcase = require('testcase')
 local errno = require('errno')
 local errno_eai = require('errno.eai')
 local addrinfo = require('net.addrinfo')
+local socket = require('net.socket')
 
 --
 -- helper
 --
 local function tmpsock()
     return os.tmpname()
+end
+
+local function is_linux()
+    -- luacov: disable
+    local fp = io.open('/proc/version', 'r')
+    if not fp then
+        return false
+    end
+    local content = fp:read('*l')
+    fp:close()
+    return content and content:find('Linux', 1, true) ~= nil
+    -- luacov: enable
 end
 
 local UNIX_PATH_MAX = 104
@@ -776,4 +789,37 @@ function testcase.port_variants_empty_string()
         socktype = 'stream',
     }))
     assert.greater(#addrs, 0)
+end
+
+function testcase.unix_addr_via_getsockname_pathname()
+    local path = tmpsock()
+    os.remove(path)
+    local ai = assert(addrinfo.unix(path, {
+        socktype = 'stream',
+    }))
+    local sock = assert(socket.bind_unix(ai))
+    -- kernel-provided sun_path may omit the trailing NUL; strnlen bounds
+    -- the read so buggy strlen paths cannot spill into uninitialised bytes.
+    local got = assert(sock:getsockname())
+    assert.equal(got:addr(), path)
+    sock:close()
+    os.remove(path)
+end
+
+function testcase.unix_addr_via_getsockname_abstract()
+    if not is_linux() then
+        return
+    end
+    -- Linux abstract socket: sun_path[0] == '\0' and the name may embed NULs.
+    local ai = assert(addrinfo.unix('\0lua-net-wi07', {
+        socktype = 'stream',
+    }))
+    local sock = assert(socket.bind_unix(ai))
+    local got = assert(sock:getsockname())
+    local addr = got:addr()
+    -- buggy strlen returned 0 chars for the leading NUL; the fix returns
+    -- the binary name intact.
+    assert.greater(#addr, 0)
+    assert.equal(addr:sub(1, 1), '\0')
+    sock:close()
 end


### PR DESCRIPTION
addr_lua walked sun_path with strlen so getsockname results without
a trailing NUL, and Linux abstract sockets whose first byte is NUL,
either read past the ai_addrlen region or returned an empty string.
net_addrinfo_new also copied ai_addrlen bytes without bounding the
source against sizeof(sockaddr_storage) or zeroing the destination.
