### PR TITLE
Refactor dgram tests

### DIFF
--- a/test/dgram/inet_test.lua
+++ b/test/dgram/inet_test.lua
@@ -1,7 +1,9 @@
 require('luacov')
 local testcase = require('testcase')
+local assert = require('assert')
 local errno = require('errno')
 local errno_eai = require('errno.eai')
+local socket = require('net.socket')
 local inet = require('net.dgram.inet')
 
 function testcase.new()
@@ -51,6 +53,25 @@ function testcase.bind()
     end), 'reuseport must be boolean', false)
 end
 
+function testcase.bind_with_reuse_opts()
+    -- opts.reuseaddr and opts.reuseport apply setsockopt before the bind
+    -- syscall so a follow-up bind on the same host/port succeeds.
+    local s1 = assert(inet.new())
+    assert(s1:bind('127.0.0.1', 0, {
+        reuseaddr = true,
+        reuseport = true,
+    }))
+    local port = assert(s1:getsockname()):port()
+
+    local s2 = assert(inet.new())
+    assert(s2:bind('127.0.0.1', port, {
+        reuseaddr = true,
+        reuseport = true,
+    }))
+    s1:close()
+    s2:close()
+end
+
 function testcase.connect()
     local s = assert(inet.new())
     local host = '127.0.0.1'
@@ -66,4 +87,18 @@ function testcase.connect()
     -- test that returns an error that nodename nor servname provided, or not known
     local _, err = inet.new():connect(host, 'invalid servname')
     assert(err.type == errno_eai.EAI_SERVICE or err.type == errno_eai.EAI_NONAME)
+end
+
+function testcase.wrap()
+    -- wrap(fd) adopts an existing UDP fd and yields a net.dgram.inet.Socket.
+    local raw = assert(socket.new_inet({
+        socktype = 'dgram',
+        protocol = 'udp',
+    }))
+    local fd = raw:unwrap()
+    local s = assert(inet.wrap(fd))
+    assert.match(tostring(s), '^net.dgram.inet.Socket: ', false)
+    assert.equal(s:family(), 'inet')
+    assert.equal(s:socktype(), 'dgram')
+    s:close()
 end

--- a/test/dgram/unix_test.lua
+++ b/test/dgram/unix_test.lua
@@ -1,18 +1,20 @@
 require('luacov')
 local testcase = require('testcase')
+local assert = require('assert')
 local errno = require('errno')
+local socket = require('net.socket')
 local unix = require('net.dgram.unix')
 
 local PATHNAME
-function testcase.before_all()
-    PATHNAME = './' .. os.time() .. '.sock'
-end
 
-function testcase.after_each()
+function testcase.before_each()
+    -- os.tmpname() gives a per-test unique path so parallel or repeated
+    -- runs cannot collide via a shared os.time() second.
+    PATHNAME = os.tmpname()
     os.remove(PATHNAME)
 end
 
-function testcase.after_all()
+function testcase.after_each()
     os.remove(PATHNAME)
 end
 
@@ -33,7 +35,6 @@ function testcase.bind()
     -- test that bind to pathanme
     local _, _, ai = assert(s:bind(PATHNAME))
     assert.equal(ai:addr(), PATHNAME)
-    s:close()
 
     -- test that returns an error that name too long
     local _, err = s:bind('./long-name-' .. string.rep('0', 500) .. '.sock')
@@ -44,6 +45,7 @@ function testcase.bind()
     _, err = s2:bind(PATHNAME)
     assert.equal(err.type, errno.EADDRINUSE)
     s2:close()
+    s:close()
 end
 
 function testcase.connect()
@@ -58,22 +60,37 @@ function testcase.connect()
     s:close()
 
     -- test that returns an error that name too long
-    local _, err = c:connect('./long-name-' .. string.rep('0', 500) .. '.sock')
+    local c2 = assert(unix.new())
+    local _, err = c2:connect('./long-name-' .. string.rep('0', 500) .. '.sock')
     assert.equal(err.type, errno.ENAMETOOLONG)
+    c2:close()
 
-    -- test that returns an error that already in use
-    c = assert(unix.new())
-    _, err = c:connect(PATHNAME)
+    -- test that connect to an unbound path is refused
+    local c3 = assert(unix.new())
+    _, err = c3:connect(PATHNAME)
     assert.equal(err.type, errno.ECONNREFUSED)
-    c:close()
+    c3:close()
 end
 
 function testcase.pair()
     -- test that create new pair instance of net.dgram.unix.Socket
-    local sp = assert(unix.pair(PATHNAME))
+    local sp = assert(unix.pair())
     assert.equal(#sp, 2)
     for _, s in ipairs(sp) do
         assert.match(tostring(s), '^net.dgram.unix.Socket: ', false)
         s:close()
     end
+end
+
+function testcase.wrap()
+    -- wrap(fd) adopts an existing AF_UNIX dgram fd.
+    local raw = assert(socket.new_unix({
+        socktype = 'dgram',
+    }))
+    local fd = raw:unwrap()
+    local s = assert(unix.wrap(fd))
+    assert.match(tostring(s), '^net.dgram.unix.Socket: ', false)
+    assert.equal(s:family(), 'unix')
+    assert.equal(s:socktype(), 'dgram')
+    s:close()
 end


### PR DESCRIPTION
- Cover dgram.inet reuse bind opts and wrap()
- Refactor dgram.unix tests for determinism (os.tmpname per test,
  drop ignored pair PATHNAME, add wrap coverage)
