### PR TITLE
Refactor stream tests

### DIFF
--- a/test/stream/inet_test.lua
+++ b/test/stream/inet_test.lua
@@ -1,5 +1,4 @@
 require('luacov')
-local io = io
 local testcase = require('testcase')
 local assert = require('assert')
 local error = require('error')
@@ -8,21 +7,48 @@ local errno_eai = require('errno.eai')
 local iovec = require('iovec')
 local inet = require('net.stream.inet')
 
+local HOST = '127.0.0.1'
+local SERVER, CLIENT, PEER
 local TESTFILE
 
-function testcase.before_all()
-    TESTFILE = './' .. os.time() .. '.txt'
-end
-
-function testcase.after_all()
+function testcase.before_each()
+    TESTFILE = os.tmpname()
     os.remove(TESTFILE)
 end
 
-function testcase.server_new()
-    local host = '127.0.0.1'
+function testcase.after_each()
+    if PEER then
+        PEER:close()
+        PEER = nil
+    end
+    if CLIENT then
+        CLIENT:close()
+        CLIENT = nil
+    end
+    if SERVER then
+        SERVER:close()
+        SERVER = nil
+    end
+    os.remove(TESTFILE)
+end
 
+-- open_pair sets SERVER, CLIENT, PEER so after_each closes them.  The
+-- caller may still close explicitly to observe close-side errors.
+local function open_pair()
+    SERVER = assert(inet.server.new(HOST, 0, {
+        reuseaddr = true,
+        reuseport = true,
+    }))
+    assert(SERVER:listen())
+    local port = assert(SERVER:getsockname()):port()
+    CLIENT = assert(inet.client.new(HOST, port))
+    PEER = assert(SERVER:accept())
+    return SERVER, CLIENT, PEER
+end
+
+function testcase.server_new()
     -- test that create new net.stream.inet.Server
-    local s, _, ai = assert(inet.server.new(host, 0, {
+    local s, _, ai = assert(inet.server.new(HOST, 0, {
         reuseaddr = true,
         reuseport = true,
     }))
@@ -40,44 +66,34 @@ function testcase.server_new()
     -- test that returns an error that nodename nor servname provided, or not known
     local _, err = inet.server.new('invalid hostname', 0)
     assert.not_nil(error.is(err, errno_eai.EAI_NONAME))
-    _, err = inet.server.new(host, 'invalid servname')
+    _, err = inet.server.new(HOST, 'invalid servname')
     assert(error.is(err, errno_eai.EAI_SERVICE) or
                error.is(err, errno_eai.EAI_NONAME))
 
     -- test that throws an error
     assert.match(assert.throws(function()
-        inet.server.new(host, 0, {
+        inet.server.new(HOST, 0, {
             reuseaddr = 1,
         })
     end), 'reuseaddr must be boolean', false)
 
     assert.match(assert.throws(function()
-        inet.server.new(host, 0, {
+        inet.server.new(HOST, 0, {
             reuseport = 'foo',
         })
     end), 'reuseport must be boolean', false)
 end
 
 function testcase.client_new()
-    local host = '127.0.0.1'
-    local s = assert(inet.server.new(host, 0, {
+    local s = assert(inet.server.new(HOST, 0, {
         reuseaddr = true,
         reuseport = true,
     }))
-    local sai = assert(s:getsockname())
-    local port = assert(sai:port())
-
-    -- NOTE: it returns a connection refused error on linux platform
-    -- test that timedout
-    -- local c, err, timeout, ai = inet.client.new(host, port, 100)
-    -- assert.is_nil(c)
-    -- assert.is_true(timeout)
-    -- assert.is_nil(err)
-    -- assert.is_nil(ai)
+    local port = assert(s:getsockname()):port()
 
     -- test that return client
     assert(s:listen())
-    local c, err, timeout, ai = assert(inet.client.new(host, port, {
+    local c, err, timeout, ai = assert(inet.client.new(HOST, port, {
         deadline = 0.1,
     }))
     assert.is_nil(err)
@@ -92,7 +108,7 @@ function testcase.client_new()
     s:close()
 
     -- test that returns error that refuse
-    c, err, timeout = inet.client.new(host, port, {
+    c, err, timeout = inet.client.new(HOST, port, {
         deadline = 0.1,
     })
     assert.is_nil(c)
@@ -101,143 +117,52 @@ function testcase.client_new()
 
     -- test that throws an error
     assert.match(assert.throws(function()
-        inet.client.new(host, port, {
+        inet.client.new(HOST, port, {
             deadline = 'foo',
         })
     end), 'deadline must be finite number', false)
 end
 
 function testcase.accept()
-    local host = '127.0.0.1'
-    local s = assert(inet.server.new(host, 0, {
-        reuseaddr = true,
-        reuseport = true,
-    }))
-    assert(s:listen())
-    local port = assert(s:getsockname()):port()
-    local c = assert(inet.client.new(host, port))
-
-    -- test that accept connection as a net.stream.inet.Socket
-    local peer = assert(s:accept())
+    local _, _, peer = open_pair()
     assert.match(tostring(peer), '^net.stream.inet.Socket: ', false)
-
-    assert(peer:close())
-    assert(c:close())
-    assert(s:close())
 end
 
 function testcase.write_read()
-    local host = '127.0.0.1'
-    local s = assert(inet.server.new(host, 0, {
-        reuseaddr = true,
-        reuseport = true,
-    }))
-    assert(s:listen())
-    local port = assert(s:getsockname()):port()
-    local c = assert(inet.client.new(host, port))
-    local peer = assert(s:accept())
-    assert.match(tostring(peer), '^net.stream.inet.Socket: ', false)
-
-    -- test that communicates with write and read
-    local msg = 'hello'
-    assert(c:write(msg))
-    local rcv = assert(peer:read())
-    assert.equal(rcv, msg)
-
-    assert(peer:close())
-    assert(c:close())
-    assert(s:close())
+    local _, c, peer = open_pair()
+    -- write from client, read on the accepted peer.
+    assert(c:write('hello'))
+    assert.equal(assert(peer:read()), 'hello')
 end
 
 function testcase.send_recv()
-    local host = '127.0.0.1'
-    local s = assert(inet.server.new(host, 0, {
-        reuseaddr = true,
-        reuseport = true,
-    }))
-    assert(s:listen())
-    local port = assert(s:getsockname()):port()
-    local c = assert(inet.client.new(host, port))
-    local peer = assert(s:accept())
-    assert.match(tostring(peer), '^net.stream.inet.Socket: ', false)
-
-    -- test that communicates with send and recv
-    local msg = 'hello'
-    assert(c:send(msg))
-    local rcv = assert(peer:recv())
-    assert.equal(rcv, msg)
-
-    assert(peer:close())
-    assert(c:close())
-    assert(s:close())
+    local _, c, peer = open_pair()
+    -- send from client, recv on the accepted peer.
+    assert(c:send('hello'))
+    assert.equal(assert(peer:recv()), 'hello')
 end
 
 function testcase.sendfile_recv()
-    local host = '127.0.0.1'
-    local s = assert(inet.server.new(host, 0, {
-        reuseaddr = true,
-        reuseport = true,
-    }))
-    assert(s:listen())
-    local port = assert(s:getsockname()):port()
-    local c = assert(inet.client.new(host, port))
-    local peer = assert(s:accept())
-    assert.match(tostring(peer), '^net.stream.inet.Socket: ', false)
-
-    -- test that communicates with sendfile and recv
-    local msg = 'hello ' .. os.time()
+    local _, c, peer = open_pair()
     local f = assert(io.open(TESTFILE, 'w+'))
-    assert(f:write(msg))
+    assert(f:write('hello'))
     assert(f:flush())
     assert(c:sendfile(f, f:seek('end')))
-    local rcv = assert(peer:recv())
-    assert.equal(rcv, msg)
-
-    assert(peer:close())
-    assert(c:close())
-    assert(s:close())
+    assert.equal(assert(peer:recv()), 'hello')
 end
 
 function testcase.sendmsg_recvmsg()
-    local host = '127.0.0.1'
-    local s = assert(inet.server.new(host, 0, {
-        reuseaddr = true,
-        reuseport = true,
-    }))
-    assert(s:listen())
-    local port = assert(s:getsockname()):port()
-    local c = assert(inet.client.new(host, port))
-    local peer = assert(s:accept())
-    assert.match(tostring(peer), '^net.stream.inet.Socket: ', false)
-
-    -- test that communicates with sendmsg and recvmsg using the new
-    -- (msg:string) API.  cmsg / addr are not used on connected TCP streams.
+    local _, c, peer = open_pair()
+    -- new (msg:string) API; cmsg / addr are not used on connected TCP.
     assert.equal(assert(c:sendmsg('hello')), 5)
-    local msg = assert(peer:recvmsg(5))
-    assert.equal(msg.data, 'hello')
+    assert.equal(assert(peer:recvmsg(5)).data, 'hello')
 
     assert.equal(assert(c:sendmsg('world')), 5)
-    msg = assert(peer:recvmsg(5))
-    assert.equal(msg.data, 'world')
-
-    assert(peer:close())
-    assert(c:close())
-    assert(s:close())
+    assert.equal(assert(peer:recvmsg(5)).data, 'world')
 end
 
 function testcase.writev_readv()
-    local host = '127.0.0.1'
-    local s = assert(inet.server.new(host, 0, {
-        reuseaddr = true,
-        reuseport = true,
-    }))
-    assert(s:listen())
-    local port = assert(s:getsockname()):port()
-    local c = assert(inet.client.new(host, port))
-    local peer = assert(s:accept())
-    assert.match(tostring(peer), '^net.stream.inet.Socket: ', false)
-
-    -- test that communicates with writev and readv message
+    local _, c, peer = open_pair()
     local iov_w = iovec.new()
     iov_w:add('hello')
     iov_w:add('world')
@@ -246,14 +171,8 @@ function testcase.writev_readv()
     assert(c:writev(iov_w))
     -- writev did not consume message
     assert(iov_w:bytes(), 10)
-    local n = assert(peer:readv(iov_r))
-    assert.equal(n, 5)
+    assert.equal(assert(peer:readv(iov_r)), 5)
     assert.equal(iov_r:concat(), iov_w:get(1))
-    n = assert(peer:readv(iov_r))
-    assert.equal(n, 5)
+    assert.equal(assert(peer:readv(iov_r)), 5)
     assert.equal(iov_r:concat(), iov_w:get(2))
-
-    assert(peer:close())
-    assert(c:close())
-    assert(s:close())
 end

--- a/test/stream/unix_test.lua
+++ b/test/stream/unix_test.lua
@@ -10,19 +10,40 @@ local unix = require('net.stream.unix')
 
 local PATHNAME
 local TESTFILE
+local SERVER, CLIENT, PEER
 
-function testcase.before_all()
-    PATHNAME = './' .. os.time() .. '.sock'
-    TESTFILE = './' .. os.time() .. '.txt'
+function testcase.before_each()
+    -- os.tmpname yields a fresh path per test so runs never collide.
+    PATHNAME = os.tmpname()
+    os.remove(PATHNAME)
+    TESTFILE = os.tmpname()
+    os.remove(TESTFILE)
 end
 
 function testcase.after_each()
-    os.remove(PATHNAME)
-end
-
-function testcase.after_all()
+    if PEER then
+        PEER:close()
+        PEER = nil
+    end
+    if CLIENT then
+        CLIENT:close()
+        CLIENT = nil
+    end
+    if SERVER then
+        SERVER:close()
+        SERVER = nil
+    end
     os.remove(PATHNAME)
     os.remove(TESTFILE)
+end
+
+-- open_pair sets SERVER/CLIENT/PEER so after_each closes them.
+local function open_pair()
+    SERVER = assert(unix.server.new(PATHNAME))
+    assert(SERVER:listen())
+    CLIENT = assert(unix.client.new(PATHNAME))
+    PEER = assert(SERVER:accept())
+    return SERVER, CLIENT, PEER
 end
 
 function testcase.server_new()
@@ -72,105 +93,46 @@ function testcase.client_new()
 end
 
 function testcase.accept()
-    local s = assert(unix.server.new(PATHNAME))
-    assert(s:listen())
-    local c = assert(unix.client.new(PATHNAME))
-
-    -- test that accept connection as a net.stream.unix.Socket
-    local peer = assert(s:accept())
+    local _, _, peer = open_pair()
     assert.match(tostring(peer), '^net.stream.unix.Socket: ', false)
-
-    assert(peer:close())
-    assert(c:close())
-    assert(s:close())
 end
 
 function testcase.write_read()
-    local s = assert(unix.server.new(PATHNAME))
-    assert(s:listen())
-    local c = assert(unix.client.new(PATHNAME))
-    local peer = assert(s:accept())
-
-    -- test that communicates with wrote and read
-    local msg = 'hello ' .. os.time()
-    assert(c:write(msg))
-    local rcv = assert(peer:read())
-    assert.equal(rcv, msg)
-
-    assert(peer:close())
-    assert(c:close())
-    assert(s:close())
+    local _, c, peer = open_pair()
+    assert(c:write('hello'))
+    assert.equal(assert(peer:read()), 'hello')
 end
 
 function testcase.send_recv()
-    local s = assert(unix.server.new(PATHNAME))
-    assert(s:listen())
-    local c = assert(unix.client.new(PATHNAME))
-    local peer = assert(s:accept())
-
-    -- test that communicates with send and recv
-    local msg = 'hello ' .. os.time()
-    assert(c:send(msg))
-    local rcv = assert(peer:recv(nil, 'peek'))
-    assert.equal(rcv, msg)
-    rcv = assert(peer:recv())
-    assert.equal(rcv, msg)
-
-    assert(peer:close())
-    assert(c:close())
-    assert(s:close())
+    local _, c, peer = open_pair()
+    assert(c:send('hello'))
+    -- peek does not consume the datagram, so a subsequent recv sees the
+    -- same bytes.
+    assert.equal(assert(peer:recv(nil, 'peek')), 'hello')
+    assert.equal(assert(peer:recv()), 'hello')
 end
 
 function testcase.sendfile_recv()
-    local s = assert(unix.server.new(PATHNAME))
-    assert(s:listen())
-    local c = assert(unix.client.new(PATHNAME))
-    local peer = assert(s:accept())
-
-    -- test that communicates with sendfile and recv
-    local msg = 'hello ' .. os.time()
+    local _, c, peer = open_pair()
     local f = assert(io.open(TESTFILE, 'w+'))
-    assert(f:write(msg))
+    assert(f:write('hello'))
     assert(f:flush())
     assert(c:sendfile(f, f:seek('end')))
-    local rcv = assert(peer:recv())
-    assert.equal(rcv, msg)
-
-    assert(peer:close())
-    assert(c:close())
-    assert(s:close())
+    assert.equal(assert(peer:recv()), 'hello')
 end
 
 function testcase.sendmsg_recvmsg()
-    local s = assert(unix.server.new(PATHNAME))
-    assert(s:listen())
-    local c = assert(unix.client.new(PATHNAME))
-    local peer = assert(s:accept())
-    assert.match(tostring(peer), '^net.stream.unix.Socket: ', false)
-
-    -- test that communicates with sendmsg and recvmsg using the new
-    -- (msg:string) API.  cmsg / addr are not used on connected unix streams.
+    local _, c, peer = open_pair()
+    -- new (msg:string) API; cmsg / addr are not used on connected unix.
     assert.equal(assert(c:sendmsg('hello')), 5)
-    local msg = assert(peer:recvmsg(5))
-    assert.equal(msg.data, 'hello')
+    assert.equal(assert(peer:recvmsg(5)).data, 'hello')
 
     assert.equal(assert(c:sendmsg('world')), 5)
-    msg = assert(peer:recvmsg(5))
-    assert.equal(msg.data, 'world')
-
-    assert(peer:close())
-    assert(c:close())
-    assert(s:close())
+    assert.equal(assert(peer:recvmsg(5)).data, 'world')
 end
 
 function testcase.writev_readv()
-    local s = assert(unix.server.new(PATHNAME))
-    assert(s:listen())
-    local c = assert(unix.client.new(PATHNAME))
-    local peer = assert(s:accept())
-    assert.match(tostring(peer), '^net.stream.unix.Socket: ', false)
-
-    -- test that communicates with writev and readv message
+    local _, c, peer = open_pair()
     local iov_w = iovec.new()
     iov_w:add('hello')
     iov_w:add('world')
@@ -179,47 +141,30 @@ function testcase.writev_readv()
     assert(c:writev(iov_w))
     -- writev did not consume message
     assert(iov_w:bytes(), 10)
-    local n = assert(peer:readv(iov_r))
-    assert.equal(n, 5)
+    assert.equal(assert(peer:readv(iov_r)), 5)
     assert.equal(iov_r:concat(), iov_w:get(1))
-    n = assert(peer:readv(iov_r))
-    assert.equal(n, 5)
+    assert.equal(assert(peer:readv(iov_r)), 5)
     assert.equal(iov_r:concat(), iov_w:get(2))
-
-    assert(peer:close())
-    assert(c:close())
-    assert(s:close())
 end
 
 function testcase.sendfd_recvfd()
-    local s = assert(unix.server.new(PATHNAME))
-    assert(s:listen())
-    local c = assert(unix.client.new(PATHNAME))
-    local peer = assert(s:accept())
-    assert.match(tostring(peer), '^net.stream.unix.Socket: ', false)
-
-    -- test that send fd to server
-    local msg = 'hello ' .. os.time()
+    local _, c, peer = open_pair()
+    -- send an open fd from client, recv it on peer, verify contents.
     local f = assert(io.open(TESTFILE, 'w+'))
-    assert(f:write(msg))
+    assert(f:write('hello'))
     assert(f:flush())
     assert(c:sendfd(fileno(f)))
     f:close()
 
-    -- test that recv fd from peer
     local fd = assert(peer:recvfd())
     f = assert(fopen(fd, 'r'))
     f:seek('set', 0)
-    assert.equal(f:read('*a'), msg)
-
-    assert(peer:close())
-    assert(c:close())
-    assert(s:close())
+    assert.equal(f:read('*a'), 'hello')
 end
 
 function testcase.pair()
-    -- test that create new pair instance of net.stream.unix.Socket
-    local sp = assert(unix.pair(PATHNAME))
+    -- unix stream pair does not need a filesystem path.
+    local sp = assert(unix.pair())
     assert.equal(#sp, 2)
     for _, s in ipairs(sp) do
         assert.match(tostring(s), '^net.stream.unix.Socket: ', false)


### PR DESCRIPTION
Both stream.inet and stream.unix tests now share an open_pair helper
plus before_each / after_each lifecycle, so each I/O testcase only
describes the API path it exercises.  os.tmpname replaces the shared
os.time-based paths, the stale timedout comment block goes away, and
unix.pair drops the argument it always ignored.
