### PR TITLE
Fix tls_bio consume and commit format on Lua 5.3+

### DIFF
--- a/src/tls_bio.c
+++ b/src/tls_bio.c
@@ -22,6 +22,7 @@
 #include "tls_bio.h"
 #include <errno.h>
 #include <pthread.h>
+#include <stdio.h>
 
 #include "lua_errno.h"
 
@@ -202,7 +203,14 @@ static int consume_lua(lua_State *L)
     lua_Integer n  = lauxh_checkinteger(L, 2);
 
     if (n < 0 || zring_consume(&bio->tx.buf, (size_t)n) != 0) {
-        return luaL_error(L, "consume(%lld): out of range", (long long)n);
+        // format directly with snprintf; lua_pushvfstring rejects %lld on
+        // Lua 5.3+ and routing through luaL_error would parse the string
+        // twice.  64 bytes covers "consume(-9223372036854775808)" comfortably.
+        char buf[64];
+        int len = snprintf(buf, sizeof(buf),
+                           "consume(%lld): out of range", (long long)n);
+        lua_pushlstring(L, buf, (size_t)len);
+        return lua_error(L);
     }
     return 0;
 }
@@ -306,7 +314,14 @@ static int commit_lua(lua_State *L)
     lua_Integer n  = lauxh_checkinteger(L, 2);
 
     if (n < 0 || zring_commit(&bio->rx.buf, (size_t)n) != 0) {
-        return luaL_error(L, "commit(%lld): out of range", (long long)n);
+        // format directly with snprintf; lua_pushvfstring rejects %lld on
+        // Lua 5.3+ and routing through luaL_error would parse the string
+        // twice.  64 bytes covers "commit(-9223372036854775808)" comfortably.
+        char buf[64];
+        int len = snprintf(buf, sizeof(buf),
+                           "commit(%lld): out of range", (long long)n);
+        lua_pushlstring(L, buf, (size_t)len);
+        return lua_error(L);
     }
     return 0;
 }

--- a/test/tls/context_test.lua
+++ b/test/tls/context_test.lua
@@ -863,3 +863,29 @@ function testcase.write_read_edge_lengths()
     sp[1]:close()
     sp[2]:close()
 end
+
+function testcase.bio_consume_and_commit_reject_negative_offsets()
+    -- consume/commit build their error message via snprintf + lua_error
+    -- because lua_pushvfstring on Lua 5.3+ refuses %lld.  Passing a
+    -- negative offset must therefore raise with the formatted message
+    -- intact rather than an "invalid option '%l'" pushfstring error.
+    local csock, ssock = make_loopback_pair()
+    local client = assert(new_tls_client())
+    local ctx = assert(tls_context.connect(client, csock:fd(), nil, true, false,
+                                           true, true, 1))
+    local bio = assert(ctx:get_bio())
+
+    local cerr = assert.throws(function()
+        bio:consume(-1)
+    end)
+    assert.match(cerr, 'consume(-1): out of range', true)
+
+    local merr = assert.throws(function()
+        bio:commit(-1)
+    end)
+    assert.match(merr, 'commit(-1): out of range', true)
+
+    ctx:close()
+    csock:close()
+    ssock:close()
+end


### PR DESCRIPTION
luaL_error("consume(%lld)", ...) relied on lua_pushvfstring, which
rejects %lld on Lua 5.3+ and masks the intended out-of-range
message.  Format the offset with snprintf and raise via lua_error
so the error survives on every supported Lua version.

## Test

New testcase `bio_consume_and_commit_reject_negative_offsets`
drives the negative-offset path and asserts the formatted message
survives, which previously failed on Lua 5.3/5.4/LuaJIT CI.