### PR TITLE
Set FD_CLOEXEC on foreign fds entering the library

### DIFF
--- a/src/cmsghdr.c
+++ b/src/cmsghdr.c
@@ -24,6 +24,7 @@
 #include "constants.h"
 #include "net_socket.h"
 // system
+#include <fcntl.h>
 #include <limits.h>
 
 // Push an lstring holding a single, self-contained cmsg block (header +
@@ -267,6 +268,11 @@ PUSH_SOL_SOCKET:
         if (nfd == 1) {
             int fd;
             memcpy(&fd, CMSG_DATA(cmh), sizeof(int));
+#ifndef MSG_CMSG_CLOEXEC
+            // Portable fallback: apply FD_CLOEXEC out-of-band on platforms
+            // where recvmsg cannot deliver the fd already CLOEXEC.
+            (void)fcntl(fd, F_SETFD, FD_CLOEXEC);
+#endif
             lua_pushinteger(L, fd);
         } else {
             lua_createtable(L, (int)nfd, 0);
@@ -275,6 +281,9 @@ PUSH_SOL_SOCKET:
                 memcpy(&fd,
                        (const unsigned char *)CMSG_DATA(cmh) + j * sizeof(int),
                        sizeof(int));
+#ifndef MSG_CMSG_CLOEXEC
+                (void)fcntl(fd, F_SETFD, FD_CLOEXEC);
+#endif
                 lua_pushinteger(L, fd);
                 lua_rawseti(L, -2, (int)(j + 1));
             }

--- a/src/socket.c
+++ b/src/socket.c
@@ -2375,7 +2375,7 @@ static int wrap_lua(lua_State *L)
         lua_pushnil(L);
         lua_errno_new(L, errno, "getsockopt");
         return 2;
-    } else if (set_nonblock(fd) == -1) {
+    } else if (set_cloexec_nonblock(fd) == -1) {
         lua_pushnil(L);
         lua_errno_new(L, errno, "fcntl");
         return 2;

--- a/src/socket.c
+++ b/src/socket.c
@@ -1840,6 +1840,12 @@ static int recvfd_lua(lua_State *L)
         .msg_controllen = ctrl.data.cmsg_len,
         .msg_flags      = 0,
     };
+#ifdef MSG_CMSG_CLOEXEC
+    // Linux 2.6.36+: ask the kernel to set FD_CLOEXEC on any fd delivered
+    // via SCM_RIGHTS atomically with the recvmsg call, so a concurrent exec
+    // cannot race in between recv and fcntl.
+    flg |= MSG_CMSG_CLOEXEC;
+#endif
     ssize_t rv = recvmsg(s->fd, &data, flg);
 
     switch (rv) {
@@ -1858,7 +1864,14 @@ static int recvfd_lua(lua_State *L)
     default:
         if (ctrl.data.cmsg_level == SOL_SOCKET &&
             ctrl.data.cmsg_type == SCM_RIGHTS) {
-            lua_pushinteger(L, *(int *)CMSG_DATA(&ctrl.data));
+            int fd = *(int *)CMSG_DATA(&ctrl.data);
+#ifndef MSG_CMSG_CLOEXEC
+            // Portable fallback for platforms without MSG_CMSG_CLOEXEC
+            // (macOS, BSD).  Not race-free with a concurrent exec, but
+            // matches the CLOEXEC default the rest of the library keeps.
+            set_cloexec(fd);
+#endif
+            lua_pushinteger(L, fd);
             return 1;
         } else if (!rv && s->socktype != SOCK_DGRAM &&
                    s->socktype != SOCK_RAW) {
@@ -1926,6 +1939,12 @@ static int recvmsg_lua(lua_State *L)
         data.msg_controllen = (socklen_t)cmsgbuf_size;
     }
 
+#ifdef MSG_CMSG_CLOEXEC
+    // See recvfd_lua: keep any SCM_RIGHTS fd out of the exec-inheritance
+    // set atomically at recv time on Linux.  cmsghdr.c applies the same
+    // CLOEXEC on the non-Linux fallback path.
+    flg |= MSG_CMSG_CLOEXEC;
+#endif
     rv = recvmsg(s->fd, &data, flg);
     if (rv == -1) {
         int err = errno;

--- a/test/socket_test.lua
+++ b/test/socket_test.lua
@@ -3081,6 +3081,36 @@ function testcase.recvfd()
     b:close()
 end
 
+function testcase.recvfd_sets_cloexec()
+    -- SCM_RIGHTS delivers a fresh fd in the receiver process.  Without
+    -- MSG_CMSG_CLOEXEC or an explicit fcntl on the extracted fd, that fd
+    -- would inherit into every subsequent exec() and defeat the CLOEXEC
+    -- default the rest of the library maintains.  Verify the received fd
+    -- is not visible after os.execute forks + execs a shell (which is
+    -- exactly the exec-inheritance scenario CLOEXEC guards against).
+    local socks = assert(socket.pair({
+        socktype = 'stream',
+    }))
+    local a = socks[1]
+    local b = socks[2]
+    local path = os.tmpname()
+    local f = assert(io.open(path, 'w+'))
+    assert(a:sendfd(fileno(f)))
+    assert(b:recvable(1))
+    local fd = assert(b:recvfd())
+    -- os.execute forks and execs /bin/sh.  If FD_CLOEXEC was set on fd,
+    -- /dev/fd/<fd> disappears in the shell.  If it was NOT set, the fd
+    -- inherits and the shell sees /dev/fd/<fd>.
+    local rv = os.execute(
+        string.format('test -e /dev/fd/%d && exit 1 || exit 0', fd))
+    assert(rv == true or rv == 0,
+           'received SCM_RIGHTS fd must be marked FD_CLOEXEC')
+    assert(socket.close(fd))
+    f:close()
+    os.remove(path)
+    a:close()
+    b:close()
+end
 function testcase.recvfd_again()
     -- No pending data: recvfd returns (nil, nil, true) to signal EAGAIN,
     -- matching recv's convention.

--- a/test/socket_test.lua
+++ b/test/socket_test.lua
@@ -4325,6 +4325,29 @@ function testcase.wrap()
     wrapped:close()
 end
 
+function testcase.wrap_sets_cloexec_and_nonblock()
+    -- The documented contract for socket.wrap(fd) is that the adopted fd
+    -- inherits both FD_CLOEXEC and O_NONBLOCK regardless of its prior
+    -- state.  Forge a raw fd whose FD_CLOEXEC is deliberately cleared and
+    -- verify wrap() re-applies both flags -- a foreign fd handed to wrap
+    -- must not leak into child processes on subsequent exec().
+    local s = assert(socket.new_inet({
+        socktype = 'stream',
+        protocol = 'tcp',
+    }))
+    assert(s:cloexec(false))
+    assert.is_false(s:cloexec())
+    assert(s:nonblock(false))
+    assert.is_false(s:nonblock())
+
+    local fd = s:unwrap()
+    local wrapped = assert(socket.wrap(fd))
+    assert.is_true(wrapped:cloexec(),
+                   'wrap() must re-apply FD_CLOEXEC to the adopted fd')
+    assert.is_true(wrapped:nonblock(),
+                   'wrap() must re-apply O_NONBLOCK to the adopted fd')
+    wrapped:close()
+end
 function testcase.unwrap_returns_fd_and_disables_socket()
     -- Explicitly exercise unwrap_lua's success path to ensure gc_thread is
     -- released and the fd is transferred back to the caller.


### PR DESCRIPTION
Two foreign-fd entry points were leaking through without FD_CLOEXEC
even though the rest of lua-net keeps that flag as its default:

- `socket.wrap(fd)` adopted a raw fd but only called `set_nonblock`,
  even though the documentation promises FD_CLOEXEC too.
- `recvfd` / `recvmsg` accepted whatever the kernel handed back for
  an SCM_RIGHTS fd, so a fork+exec after receiving would inherit it.

Both are now covered.  `wrap()` uses `set_cloexec_nonblock`, and the
receive paths ask for `MSG_CMSG_CLOEXEC` (Linux 2.6.36+) with a
portable `fcntl` fallback for macOS/BSD.  The commits are split so
either half can be reviewed or reverted independently.
