### PR TITLE
Fix rcvtimeo/sndtimeo passing NaN or Inf to modf

### DIFF
--- a/src/sockopts.h
+++ b/src/sockopts.h
@@ -26,6 +26,7 @@
 #include "net_socket.h"
 #include "optcheck.h"
 
+#include <limits.h>
 #include <math.h>
 
 typedef struct {
@@ -169,6 +170,18 @@ static inline int sockopts_check_int(lua_State *L, const char *name, void *ctx)
     return 0;
 }
 
+// Reject non-finite, negative, or magnitude-out-of-range timeout values
+// so the later modf/(time_t) cast never invokes C UB.  ldexp gives an
+// exact power of two for the upper bound, and the (time_t)-1 test decides
+// whether the type is signed so 32- and 64-bit platforms use the right
+// exponent without hardcoding LLONG_MAX / INT64_MAX.
+static inline int sockopts_timeout_is_valid(double sec)
+{
+    const double limit = ldexp(1.0, (int)(sizeof(time_t) * CHAR_BIT -
+                                          (((time_t)-1 < (time_t)0) ? 1 : 0)));
+    return isfinite(sec) && sec >= 0.0 && sec < limit;
+}
+
 static inline int sockopts_check_timeval(lua_State *L, const char *name,
                                          void *ctx)
 {
@@ -180,6 +193,12 @@ static inline int sockopts_check_timeval(lua_State *L, const char *name,
                           luaL_typename(L, -1));
     }
     value = lua_tonumber(L, -1);
+    if (!sockopts_timeout_is_valid(value)) {
+        return luaL_error(L,
+                          "opts.%s must be a finite, non-negative number"
+                          " within the time_t range",
+                          name);
+    }
 
     if (strcmp(name, "rcvtimeo") == 0) {
         opts->rcvtimeo_set = 1;
@@ -274,6 +293,12 @@ static inline int sockopts_timeval_lua(lua_State *L, int fd, int level, int opt,
         double lo   = 0;
         double tnum = (double)luaL_checknumber(L, 2);
 
+        if (!sockopts_timeout_is_valid(tnum)) {
+            lua_pushnil(L);
+            errno = EINVAL;
+            lua_errno_new(L, errno, name);
+            return 2;
+        }
         lo           = modf(tnum, &hi);
         tval.tv_sec  = (time_t)hi;
         tval.tv_usec = (suseconds_t)(lo * 1000000);

--- a/test/socket_test.lua
+++ b/test/socket_test.lua
@@ -212,6 +212,8 @@ function testcase.new_inet_setsockopt_failures()
 
     -- Kernels likewise differ on whether the remaining negative option values
     -- are rejected or normalized, so accept either coherent outcome here.
+    -- rcvtimeo / sndtimeo have their own dedicated rejection testcase
+    -- because negative values are refused at the C boundary now.
     for _, opts in ipairs({
         {
             tcpkeepintvl = -1,
@@ -227,12 +229,6 @@ function testcase.new_inet_setsockopt_failures()
         },
         {
             rcvlowat = -1,
-        },
-        {
-            rcvtimeo = -1,
-        },
-        {
-            sndtimeo = -1,
         },
     }) do
         opts.socktype = 'stream'
@@ -1129,6 +1125,55 @@ function testcase.sndtimeo()
     rv, err = s:sndtimeo(0.5)
     assert.is_nil(rv)
     assert(err)
+end
+
+function testcase.rcvtimeo_and_sndtimeo_reject_nan_inf_and_out_of_range()
+    -- The C bindings cast the caller-supplied double straight through
+    -- modf + (time_t)/(suseconds_t) casts.  NaN, +/-Inf, negative
+    -- values, and magnitudes that do not fit in time_t all invoke
+    -- undefined behaviour once cast, so the C boundary must reject them.
+    -- Method setters return (nil, EINVAL); constructor helpers raise a
+    -- Lua error the same way type mismatches do.
+    local s = assert(socket.new_inet({
+        socktype = 'stream',
+        protocol = 'tcp',
+    }))
+    for _, bad in ipairs({
+        math.huge,
+        -math.huge,
+        0 / 0,
+        1e30,
+        -1,
+    }) do
+        local rv, err = s:rcvtimeo(bad)
+        assert.is_nil(rv, 'rcvtimeo must reject ' .. tostring(bad))
+        assert(err)
+        assert.equal(err.type, errno.EINVAL)
+
+        rv, err = s:sndtimeo(bad)
+        assert.is_nil(rv, 'sndtimeo must reject ' .. tostring(bad))
+        assert(err)
+        assert.equal(err.type, errno.EINVAL)
+
+        local terr = assert.throws(function()
+            socket.new_inet({
+                socktype = 'stream',
+                protocol = 'tcp',
+                rcvtimeo = bad,
+            })
+        end)
+        assert.match(terr, 'opts.rcvtimeo', false)
+
+        terr = assert.throws(function()
+            socket.new_inet({
+                socktype = 'stream',
+                protocol = 'tcp',
+                sndtimeo = bad,
+            })
+        end)
+        assert.match(terr, 'opts.sndtimeo', false)
+    end
+    s:close()
 end
 
 function testcase.linger()


### PR DESCRIPTION
sockopts_check_timeval and sockopts_timeval_lua fed the caller
number to modf and cast the result to time_t / suseconds_t.  NaN,
+/-Inf, and values that do not fit in the destination integer type
all invoke C UB after the cast, so a caller reaching the low-level
setter with math.huge could crash or misbehave.  Reject non-finite
values and values outside +/-LLONG_MAX at the C boundary.
