### PR TITLE
Drop deprecated AI_IDN_* getaddrinfo flags

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -318,12 +318,6 @@ static const net_constant_t NET_ADDRINFO_FLAG_MAP[] = {
 #ifdef AI_CANONIDN
     {"canonidn",                 AI_CANONIDN                },
 #endif
-#ifdef AI_IDN_ALLOW_UNASSIGNED
-    {"idn_allow_unassigned",     AI_IDN_ALLOW_UNASSIGNED    },
-#endif
-#ifdef AI_IDN_USE_STD3_ASCII_RULES
-    {"idn_use_std3_ascii_rules", AI_IDN_USE_STD3_ASCII_RULES},
-#endif
 #ifdef AI_FQDN
     {"fqdn",                     AI_FQDN                    },
 #endif


### PR DESCRIPTION
glibc deprecated AI_IDN_ALLOW_UNASSIGNED and
AI_IDN_USE_STD3_ASCII_RULES years ago; keeping their entries in
NET_ADDRINFO_FLAG_MAP only produces a compile-time warning on
every build without offering the caller anything the underlying
resolver still honours.  Remove both entries so the flags no
longer appear on the Lua side.
