### PR TITLE
Fix addrinfo.unix padding abstract socket names

### DIFF
--- a/src/addrinfo.c
+++ b/src/addrinfo.c
@@ -759,7 +759,19 @@ static int unix_lua(lua_State *L)
         return 2;
     }
     memcpy((void *)&saddr.sun_path, (void *)pathname, len);
-    saddr.sun_path[len] = 0;
+
+    if (len == 0 || pathname[0] == '\0') {
+        // Empty or abstract-style name (Linux abstract socket).  The kernel
+        // takes addrlen as the exact name length; a trailing NUL would
+        // extend the name by one byte.  Do not write one.
+        ai.ai_addrlen = offsetof(struct sockaddr_un, sun_path) + len;
+    } else {
+        // Filesystem pathname: kernel searches sun_path[0..addrlen-offsetof]
+        // for a NUL to delimit the name, so addrlen must cover the
+        // terminator we write here.
+        saddr.sun_path[len] = 0;
+        ai.ai_addrlen       = offsetof(struct sockaddr_un, sun_path) + len + 1;
+    }
 
     // create addrinfo
     net_addrinfo_new(L, &ai);

--- a/test/addrinfo_test.lua
+++ b/test/addrinfo_test.lua
@@ -679,16 +679,16 @@ function testcase.unix_addr_via_getsockname_abstract()
         return
     end
     -- Linux abstract socket: sun_path[0] == '\0' and the name may embed NULs.
-    local ai = assert(addrinfo.unix('\0lua-net-wi07', {
+    local name = '\0lua-net-wi07-' .. tostring(os.time())
+    local ai = assert(addrinfo.unix(name, {
         socktype = 'stream',
     }))
     local sock = assert(socket.bind_unix(ai))
     local got = assert(sock:getsockname())
-    local addr = got:addr()
-    -- buggy strlen returned 0 chars for the leading NUL; the fix returns
-    -- the binary name intact.
-    assert.greater(#addr, 0)
-    assert.equal(addr:sub(1, 1), '\0')
+    -- ai_addrlen was previously sizeof(sockaddr_un), so the kernel padded
+    -- the abstract name with trailing NULs.  With the fix the round-trip
+    -- returns the exact binary name the caller passed.
+    assert.equal(got:addr(), name)
     sock:close()
 end
 


### PR DESCRIPTION
Linux abstract sockets take ai_addrlen as the exact name length,
but addrinfo.unix always passed sizeof(sockaddr_un).  A caller
naming "\0foo" ended up bound to "\0foo\0\0..." padded to the
full struct size instead of "\0foo".  Set ai_addrlen from the
Lua string length and terminate only pathname names, so the
kernel sees the intended abstract name.
