### PR TITLE
Fix TLS timeouts compounding across bio helpers

### DIFF
--- a/lib/tls.lua
+++ b/lib/tls.lua
@@ -31,25 +31,23 @@ local WANT_POLLOUT = require('net.tls.context').WANT_WRITE
 --- @class net.tls.Socket : net.Socket
 local Socket = {}
 
---- bio_fill
---- @private
---- @param sec number?
+--- bio_fill core: use the caller's deadline object directly instead of
+--- creating a fresh one so callers can share their total budget across
+--- bio_drain / bio_fill / poll_wait iterations.
+--- @param self net.tls.Socket
+--- @param deadline time.clock.deadline?
 --- @return boolean ok
 --- @return any err
 --- @return boolean? timeout
-function Socket:bio_fill(sec)
+local function bio_fill(self, deadline)
     local bio = self.tls_bio
     if not bio then
         return true
     end
 
-    local deadline = sec and new_deadline(sec)
     while true do
-        if deadline then
-            sec = deadline:remain()
-            if sec <= 0 then
-                return false, nil, true
-            end
+        if deadline and deadline:is_done() then
+            return false, nil, true
         end
 
         local n, err, again = bio:fill()
@@ -57,6 +55,11 @@ function Socket:bio_fill(sec)
             return true
         elseif not again then
             return false, err
+        end
+
+        local done, sec = deadline:is_done()
+        if done then
+            return false, nil, true
         end
 
         local ok, timeout
@@ -68,25 +71,32 @@ function Socket:bio_fill(sec)
     end
 end
 
---- bio_drain
+--- bio_fill
 --- @private
 --- @param sec number?
 --- @return boolean ok
 --- @return any err
 --- @return boolean? timeout
-function Socket:bio_drain(sec)
+function Socket:bio_fill(sec)
+    local deadline = sec and new_deadline(sec)
+    return bio_fill(self, deadline)
+end
+
+--- bio_drain core: same rationale as bio_fill.
+--- @param self net.tls.Socket
+--- @param deadline time.clock.deadline?
+--- @return boolean ok
+--- @return any err
+--- @return boolean? timeout
+local function bio_drain(self, deadline)
     local bio = self.tls_bio
     if not bio then
         return true
     end
 
-    local deadline = sec and new_deadline(sec)
     while true do
-        if deadline then
-            sec = deadline:remain()
-            if sec <= 0 then
-                return false, nil, true
-            end
+        if deadline and deadline:is_done() then
+            return false, nil, true
         end
 
         local n, err, again = bio:drain()
@@ -94,6 +104,11 @@ function Socket:bio_drain(sec)
             return true
         elseif not again then
             return false, err
+        end
+
+        local done, sec = deadline:is_done()
+        if done then
+            return false, nil, true
         end
 
         local ok, timeout
@@ -105,6 +120,67 @@ function Socket:bio_drain(sec)
     end
 end
 
+--- bio_drain
+--- @private
+--- @param sec number?
+--- @return boolean ok
+--- @return any err
+--- @return boolean? timeout
+function Socket:bio_drain(sec)
+    local deadline = sec and new_deadline(sec)
+    return bio_drain(self, deadline)
+end
+
+--- poll_wait core: caller passes its deadline so bio_drain + bio_fill share
+--- one budget instead of each restarting a fresh sec timer.
+--- @param self net.tls.Socket
+--- @param want integer
+--- @param deadline time.clock.deadline?
+--- @return boolean ok
+--- @return any err
+--- @return boolean? timeout
+local function poll_wait(self, want, deadline)
+    if want == WANT_POLLIN then
+        -- if use BIO, drain any pending encrypted record(s) to fd first (the
+        -- peer may be waiting for our outgoing data, e.g. handshake flights),
+        -- then fill the buffer with newly received ciphertext(s) from fd.
+        if self.tls_bio then
+            local ok, err, timeout = bio_drain(self, deadline)
+            if not ok then
+                return false, err, timeout
+            end
+            return bio_fill(self, deadline)
+        end
+
+        local sec
+        if deadline then
+            local done
+            done, sec = deadline:is_done()
+            if done then
+                return false, nil, true
+            end
+        end
+        return self:wait_readable(sec)
+    elseif want == WANT_POLLOUT then
+        -- if use BIO, drain the newly encrypted record(s) to fd
+        if self.tls_bio then
+            return bio_drain(self, deadline)
+        end
+        local sec
+        if deadline then
+            local done
+            done, sec = deadline:is_done()
+            if done then
+                return false, nil, true
+            end
+        end
+        return self:wait_writable(sec)
+    end
+
+    return false,
+           new_errno('EINVAL', format('unknown want type %q', tostring(want)))
+end
+
 --- poll_wait
 --- @param want integer
 --- @param sec number?
@@ -112,28 +188,8 @@ end
 --- @return any err
 --- @return boolean? timeout
 function Socket:poll_wait(want, sec)
-    -- wait by poll function
-    if want == WANT_POLLIN then
-        -- if use BIO, drain any pending encrypted record(s) to fd first (the
-        -- peer may be waiting for our outgoing data, e.g. handshake flights),
-        -- then fill the buffer with newly received ciphertext(s) from fd.
-        if self.tls_bio then
-            local ok, err, timeout = self:bio_drain(sec)
-            if not ok then
-                return false, err, timeout
-            end
-            return self:bio_fill(sec)
-        end
-        return self:wait_readable(sec)
-    elseif want == WANT_POLLOUT then
-        -- if use BIO, drain the newly encrypted record(s) to fd
-        if self.tls_bio then
-            return self:bio_drain(sec)
-        end
-        return self:wait_writable(sec)
-    end
-    return false,
-           new_errno('EINVAL', format('unknown want type %q', tostring(want)))
+    local deadline = sec and new_deadline(sec)
+    return poll_wait(self, want, deadline)
 end
 
 --- closer
@@ -174,23 +230,21 @@ function Socket:tls_close()
 
             -- close succeeded
             -- if use BIO, drain the newly encrypted record(s) to fd
-            local done, sec = deadline:is_done()
-            if done then
+            if deadline:is_done() then
                 return false, nil, true
             end
-            ok, err, timeout = self:bio_drain(sec)
+            ok, err, timeout = bio_drain(self, deadline)
             if not ok then
                 return false, err, timeout
             end
             return true
         end
 
-        local done, sec = deadline:is_done()
-        if done then
+        if deadline:is_done() then
             return false, nil, true
         end
 
-        ok, err, timeout = self:poll_wait(want, sec)
+        ok, err, timeout = poll_wait(self, want, deadline)
         if not ok then
             return false, err, timeout
         end
@@ -221,20 +275,21 @@ function Socket:get_alpn()
     return self.tls:get_alpn()
 end
 
---- handshake
+--- handshake_core: run the handshake against a caller-provided deadline
+--- (falls back to sndtimeo when called outside of read/write).
+--- @param self net.tls.Socket
+--- @param deadline time.clock.deadline
 --- @return boolean ok
 --- @return any err
 --- @return boolean? timeout
-function Socket:handshake()
+local function handshake(self, deadline)
     if self.handshaked then
         return true
     end
 
-    local tls, handshake = self.tls, self.tls.handshake
-    local deadline = self:get_send_deadline()
-
+    local tls, handshake_fn = self.tls, self.tls.handshake
     while true do
-        local ok, err, want = handshake(tls)
+        local ok, err, want = handshake_fn(tls)
         local timeout
 
         if not want then
@@ -245,26 +300,35 @@ function Socket:handshake()
 
             -- handshake succeeded
             -- if use BIO, drain the newly encrypted record(s) to fd
-            local done, sec = deadline:is_done()
-            if done then
+            if deadline:is_done() then
                 return false, nil, true
             end
-            self.handshaked, err, timeout = self:bio_drain(sec)
+            self.handshaked, err, timeout = bio_drain(self, deadline)
             return self.handshaked, err, timeout
         end
 
-        local done, sec = deadline:is_done()
-        if done then
+        if deadline:is_done() then
             return false, nil, true
         end
 
-        ok, err, timeout = self:poll_wait(want, sec)
+        ok, err, timeout = poll_wait(self, want, deadline)
         if not ok then
             -- error or timeout occurred
             return false, err, timeout
         end
         -- do handshake again
     end
+end
+
+--- handshake
+--- @return boolean ok
+--- @return any err
+--- @return boolean? timeout
+function Socket:handshake()
+    if self.handshaked then
+        return true
+    end
+    return handshake(self, self:get_send_deadline())
 end
 
 --- read
@@ -275,9 +339,11 @@ end
 function Socket:read(bufsize)
     local deadline = self:get_recv_deadline()
 
-    -- perform handshake if not yet
+    -- perform handshake if not yet, sharing the read deadline so
+    -- handshake + read together fit within rcvtimeo instead of taking a
+    -- fresh sndtimeo budget on top.
     if not self.handshaked then
-        local ok, err, timeout = self:handshake()
+        local ok, err, timeout = handshake(self, deadline)
         if not ok then
             return nil, err, timeout
         end
@@ -292,8 +358,7 @@ function Socket:read(bufsize)
     local nread = 0
 
     while true do
-        local done, sec = deadline:is_done()
-        if done then
+        if deadline:is_done() then
             return nil, nil, true
         end
 
@@ -309,7 +374,7 @@ function Socket:read(bufsize)
 
             -- read succeeded
             -- if use BIO, drain the newly encrypted record(s) to fd
-            ok, err, timeout = self:bio_drain(sec)
+            ok, err, timeout = bio_drain(self, deadline)
             if not ok then
                 return nil, err, timeout
             end
@@ -318,7 +383,7 @@ function Socket:read(bufsize)
 
         if nread > 5 then
             nread = 0
-            ok, err, timeout = self:poll_wait(want, sec)
+            ok, err, timeout = poll_wait(self, want, deadline)
             if not ok then
                 return nil, err, timeout
             end
@@ -362,9 +427,10 @@ end
 function Socket:write(str)
     local deadline = self:get_send_deadline()
 
-    -- perform handshake if not yet
+    -- perform handshake if not yet, sharing the write deadline (see
+    -- Socket:read for the rationale).
     if not self.handshaked then
-        local ok, err, timeout = self:handshake()
+        local ok, err, timeout = handshake(self, deadline)
         if not ok then
             return 0, err, timeout
         end
@@ -374,8 +440,7 @@ function Socket:write(str)
     local sent = 0
 
     while true do
-        local done, sec = deadline:is_done()
-        if done then
+        if deadline:is_done() then
             return sent, nil, true
         end
 
@@ -390,14 +455,14 @@ function Socket:write(str)
         if not want then
             -- write succeeded
             -- if use BIO, drain the newly encrypted record(s) to fd
-            ok, err, timeout = self:bio_drain(sec)
+            ok, err, timeout = bio_drain(self, deadline)
             if not ok then
                 return nil, err, timeout
             end
             return sent
         end
 
-        ok, err, timeout = self:poll_wait(want, sec)
+        ok, err, timeout = poll_wait(self, want, deadline)
         if not ok then
             return sent, err, timeout
         end

--- a/test/tls/stream/inet_test.lua
+++ b/test/tls/stream/inet_test.lua
@@ -610,6 +610,61 @@ function testcase.write_read_bio()
     assert(p:wait())
 end
 
+function testcase.read_shares_rcvtimeo_with_first_handshake()
+    -- Before the fix, a read that triggered the initial handshake let the
+    -- handshake take its own sndtimeo budget instead of respecting the
+    -- caller's rcvtimeo.  With rcvtimeo=1s and sndtimeo=5s a handshake
+    -- against a silent peer used to block for ~5s; now it must timeout
+    -- within rcvtimeo.
+    local host = '127.0.0.1'
+    local s = assert(inet.server.new(host, 0, {
+        reuseaddr = true,
+        reuseport = true,
+        tlscfg = {
+            cert = SERVER_CONFIG.cert,
+            key = SERVER_CONFIG.key,
+            use_bio = true,
+        },
+    }))
+    assert(s:listen())
+    local port = assert(s:getsockname()):port()
+
+    local p = fork()
+    if p:is_child() then
+        s:close()
+        -- open a plain TCP socket to the TLS server and never send
+        -- anything.  The peer will start the TLS handshake wait; from
+        -- the server side we call read() with a short rcvtimeo and a
+        -- longer sndtimeo -- read must honour rcvtimeo.
+        local plain = require('net.stream.inet')
+        local raw = assert(plain.client.new(host, port))
+        raw:read(nil, 5)  -- keep the connection alive without sending
+        raw:close()
+        return
+    end
+    local peer = assert(s:accept())
+    assert(peer:rcvtimeo(1))
+    assert(peer:sndtimeo(5))
+
+    local gettime = require('time.clock').gettime
+    local t0 = gettime()
+    local msg, err, timeout = peer:read()
+    local elapsed = gettime() - t0
+
+    assert.is_nil(msg)
+    assert.is_nil(err)
+    assert.is_true(timeout, 'read must surface timeout=true')
+    assert(elapsed < 1.5, string.format(
+               'handshake during read took %.3fs, expected within rcvtimeo' ..
+                   ' (1s) plus jitter; bug allowed up to sndtimeo (5s)',
+               elapsed))
+
+    peer:close()
+    s:close()
+    assert(p:wait())
+end
+
+
 function testcase.write_read_bio_large_payload()
     -- SSL_MODE_ENABLE_PARTIAL_WRITE is enabled on the client SSL_CTX, so a
     -- plaintext payload larger than a single TLS record is delivered in


### PR DESCRIPTION
bio_fill, bio_drain and poll_wait each new_deadline'd their own
sec argument, so read()/write() saw a timeout of roughly 2 *
rcvtimeo when both helpers had to wait, and read() triggering a
first handshake burned sndtimeo on top of rcvtimeo.  Extract the
core logic into local functions that take a shared deadline and
route internal calls through them; the public methods keep their
sec signature by wrapping the shared function.
