### PR TITLE
Fix TLS bio helpers crashing on nil deadline

### DIFF
--- a/lib/tls.lua
+++ b/lib/tls.lua
@@ -35,7 +35,7 @@ local Socket = {}
 --- creating a fresh one so callers can share their total budget across
 --- bio_drain / bio_fill / poll_wait iterations.
 --- @param self net.tls.Socket
---- @param deadline time.clock.deadline?
+--- @param deadline time.clock.deadline
 --- @return boolean ok
 --- @return any err
 --- @return boolean? timeout
@@ -46,7 +46,7 @@ local function bio_fill(self, deadline)
     end
 
     while true do
-        if deadline and deadline:is_done() then
+        if deadline:is_done() then
             return false, nil, true
         end
 
@@ -72,19 +72,21 @@ local function bio_fill(self, deadline)
 end
 
 --- bio_fill
+--- If sec is omitted, the deadline falls back to rcvtimeo (or the default
+--- max timeout when unset) so the EAGAIN path always has a deadline.
 --- @private
 --- @param sec number?
 --- @return boolean ok
 --- @return any err
 --- @return boolean? timeout
 function Socket:bio_fill(sec)
-    local deadline = sec and new_deadline(sec)
+    local deadline = sec and new_deadline(sec) or self:get_recv_deadline()
     return bio_fill(self, deadline)
 end
 
 --- bio_drain core: same rationale as bio_fill.
 --- @param self net.tls.Socket
---- @param deadline time.clock.deadline?
+--- @param deadline time.clock.deadline
 --- @return boolean ok
 --- @return any err
 --- @return boolean? timeout
@@ -95,7 +97,7 @@ local function bio_drain(self, deadline)
     end
 
     while true do
-        if deadline and deadline:is_done() then
+        if deadline:is_done() then
             return false, nil, true
         end
 
@@ -121,13 +123,15 @@ local function bio_drain(self, deadline)
 end
 
 --- bio_drain
+--- If sec is omitted, the deadline falls back to sndtimeo (or the default
+--- max timeout when unset) so the EAGAIN path always has a deadline.
 --- @private
 --- @param sec number?
 --- @return boolean ok
 --- @return any err
 --- @return boolean? timeout
 function Socket:bio_drain(sec)
-    local deadline = sec and new_deadline(sec)
+    local deadline = sec and new_deadline(sec) or self:get_send_deadline()
     return bio_drain(self, deadline)
 end
 
@@ -135,7 +139,7 @@ end
 --- one budget instead of each restarting a fresh sec timer.
 --- @param self net.tls.Socket
 --- @param want integer
---- @param deadline time.clock.deadline?
+--- @param deadline time.clock.deadline
 --- @return boolean ok
 --- @return any err
 --- @return boolean? timeout
@@ -152,13 +156,9 @@ local function poll_wait(self, want, deadline)
             return bio_fill(self, deadline)
         end
 
-        local sec
-        if deadline then
-            local done
-            done, sec = deadline:is_done()
-            if done then
-                return false, nil, true
-            end
+        local done, sec = deadline:is_done()
+        if done then
+            return false, nil, true
         end
         return self:wait_readable(sec)
     elseif want == WANT_POLLOUT then
@@ -166,13 +166,9 @@ local function poll_wait(self, want, deadline)
         if self.tls_bio then
             return bio_drain(self, deadline)
         end
-        local sec
-        if deadline then
-            local done
-            done, sec = deadline:is_done()
-            if done then
-                return false, nil, true
-            end
+        local done, sec = deadline:is_done()
+        if done then
+            return false, nil, true
         end
         return self:wait_writable(sec)
     end
@@ -182,13 +178,23 @@ local function poll_wait(self, want, deadline)
 end
 
 --- poll_wait
+--- If sec is omitted, the deadline falls back to rcvtimeo or sndtimeo
+--- according to the want direction (or the default max timeout when the
+--- corresponding timeout is unset).
 --- @param want integer
 --- @param sec number?
 --- @return boolean ok
 --- @return any err
 --- @return boolean? timeout
 function Socket:poll_wait(want, sec)
-    local deadline = sec and new_deadline(sec)
+    local deadline
+    if sec then
+        deadline = new_deadline(sec)
+    elseif want == WANT_POLLIN then
+        deadline = self:get_recv_deadline()
+    elseif want == WANT_POLLOUT then
+        deadline = self:get_send_deadline()
+    end
     return poll_wait(self, want, deadline)
 end
 

--- a/test/tls/stream/inet_test.lua
+++ b/test/tls/stream/inet_test.lua
@@ -7,6 +7,7 @@ local error_is = require('error').is
 local errno = require('errno')
 local errno_eai = require('errno.eai')
 local inet = require('net.stream.inet')
+local tls_context = require('net.tls.context')
 local new_tls_server = require('net.tls.server')
 
 local SERVER_CONFIG
@@ -605,6 +606,204 @@ function testcase.write_read_bio()
 
     local rcv = assert(peer:read())
     assert.equal(rcv, msg)
+    peer:close()
+    s:close()
+    assert(p:wait())
+end
+
+function testcase.bio_fill_without_timeout_does_not_crash()
+    -- The internal deadline object was nil when Socket:bio_fill was
+    -- called without a sec argument, but the EAGAIN path invoked
+    -- deadline:is_done() unconditionally.  On a non-blocking socket
+    -- that immediately returns EAGAIN the old code raised "attempt to
+    -- index a nil value".  Replace tls_bio with a stub whose fill()
+    -- reports EAGAIN deterministically (a real peer may deliver EOF
+    -- instead of EAGAIN once the client closes, which made the test
+    -- racy), and let the stubbed wait_readable prove that a deadline
+    -- was materialized (non-nil remaining sec) before waiting.
+    local host = '127.0.0.1'
+    local s = assert(inet.server.new(host, 0, {
+        reuseaddr = true,
+        reuseport = true,
+        tlscfg = {
+            cert = SERVER_CONFIG.cert,
+            key = SERVER_CONFIG.key,
+            use_bio = true,
+        },
+    }))
+    assert(s:listen())
+    local port = assert(s:getsockname()):port()
+
+    local p = fork()
+    if p:is_child() then
+        s:close()
+        local c = assert(inet.client.new(host, port, {
+            tlscfg = {
+                noverify_name = CLIENT_CONFIG.noverify_name,
+                noverify_time = CLIENT_CONFIG.noverify_time,
+                noverify_cert = CLIENT_CONFIG.noverify_cert,
+                use_bio = true,
+            },
+        }))
+        c:close()
+        return
+    end
+    local peer = assert(s:accept())
+    assert(peer.tls_bio ~= nil, 'BIO not set on peer')
+
+    local bio = peer.tls_bio
+    local again = errno.new('EAGAIN')
+    peer.tls_bio = {
+        fill = function()
+            return nil, again, true
+        end,
+    }
+
+    -- sentinel only the stubbed wait can produce; the stub also asserts
+    -- that the deadline provided a numeric remaining sec.
+    local sentinel = errno.new('ECANCELED', 'test-sentinel')
+    peer.wait_readable = function(_, sec)
+        assert(type(sec) == 'number', 'remaining sec must be a number')
+        return false, sentinel
+    end
+
+    local ok, err = peer:bio_fill()
+    assert.is_false(ok)
+    assert.equal(err, sentinel,
+                 'bio_fill without deadline must reach wait_readable')
+
+    peer.tls_bio = bio
+    peer:close()
+    s:close()
+    assert(p:wait())
+end
+
+function testcase.bio_drain_without_timeout_does_not_crash()
+    -- Same bug class as bio_fill_without_timeout_does_not_crash: with no sec
+    -- argument the internal deadline was nil and the EAGAIN path of
+    -- bio_drain crashed on deadline:is_done().  Replace tls_bio with a
+    -- stub whose drain() reports EAGAIN, and let the stubbed wait_writable
+    -- verify that a deadline was materialized (non-nil remaining sec)
+    -- before waiting.
+    local host = '127.0.0.1'
+    local s = assert(inet.server.new(host, 0, {
+        reuseaddr = true,
+        reuseport = true,
+        tlscfg = {
+            cert = SERVER_CONFIG.cert,
+            key = SERVER_CONFIG.key,
+            use_bio = true,
+        },
+    }))
+    assert(s:listen())
+    local port = assert(s:getsockname()):port()
+
+    local p = fork()
+    if p:is_child() then
+        s:close()
+        local c = assert(inet.client.new(host, port, {
+            tlscfg = {
+                noverify_name = CLIENT_CONFIG.noverify_name,
+                noverify_time = CLIENT_CONFIG.noverify_time,
+                noverify_cert = CLIENT_CONFIG.noverify_cert,
+                use_bio = true,
+            },
+        }))
+        c:close()
+        return
+    end
+    local peer = assert(s:accept())
+    assert(peer.tls_bio ~= nil, 'BIO not set on peer')
+
+    local bio = peer.tls_bio
+    local again = errno.new('EAGAIN')
+    peer.tls_bio = {
+        drain = function()
+            return nil, again, true
+        end,
+    }
+
+    -- sentinel only the stubbed wait can produce; the stub also asserts
+    -- that the deadline provided a numeric remaining sec.
+    local sentinel = errno.new('ECANCELED', 'test-sentinel')
+    peer.wait_writable = function(_, sec)
+        assert(type(sec) == 'number', 'remaining sec must be a number')
+        return false, sentinel
+    end
+
+    local ok, err = peer:bio_drain()
+    assert.is_false(ok)
+    assert.equal(err, sentinel,
+                 'bio_drain without deadline must reach wait_writable')
+
+    peer.tls_bio = bio
+    peer:close()
+    s:close()
+    assert(p:wait())
+end
+
+function testcase.poll_wait_without_timeout_does_not_crash()
+    -- poll_wait without sec must materialize a deadline from the want
+    -- direction (WANT_POLLOUT -> sndtimeo, WANT_POLLIN -> rcvtimeo via
+    -- bio_drain) instead of passing nil down to the EAGAIN path.
+    local host = '127.0.0.1'
+    local s = assert(inet.server.new(host, 0, {
+        reuseaddr = true,
+        reuseport = true,
+        tlscfg = {
+            cert = SERVER_CONFIG.cert,
+            key = SERVER_CONFIG.key,
+            use_bio = true,
+        },
+    }))
+    assert(s:listen())
+    local port = assert(s:getsockname()):port()
+
+    local p = fork()
+    if p:is_child() then
+        s:close()
+        local c = assert(inet.client.new(host, port, {
+            tlscfg = {
+                noverify_name = CLIENT_CONFIG.noverify_name,
+                noverify_time = CLIENT_CONFIG.noverify_time,
+                noverify_cert = CLIENT_CONFIG.noverify_cert,
+                use_bio = true,
+            },
+        }))
+        c:close()
+        return
+    end
+    local peer = assert(s:accept())
+    assert(peer.tls_bio ~= nil, 'BIO not set on peer')
+
+    local bio = peer.tls_bio
+    local again = errno.new('EAGAIN')
+    peer.tls_bio = {
+        drain = function()
+            return nil, again, true
+        end,
+    }
+
+    local sentinel = errno.new('ECANCELED', 'test-sentinel')
+    peer.wait_writable = function(_, sec)
+        assert(type(sec) == 'number', 'remaining sec must be a number')
+        return false, sentinel
+    end
+
+    -- WANT_POLLOUT takes the bio_drain path directly
+    local ok, err = peer:poll_wait(tls_context.WANT_WRITE)
+    assert.is_false(ok)
+    assert.equal(err, sentinel,
+                 'poll_wait(WANT_POLLOUT) without deadline must reach wait_writable')
+
+    -- WANT_POLLIN drains pending record(s) first, so the same stub covers
+    -- the recv-direction deadline selection
+    ok, err = peer:poll_wait(tls_context.WANT_READ)
+    assert.is_false(ok)
+    assert.equal(err, sentinel,
+                 'poll_wait(WANT_POLLIN) without deadline must reach wait_writable')
+
+    peer.tls_bio = bio
     peer:close()
     s:close()
     assert(p:wait())


### PR DESCRIPTION
`Socket:bio_fill`, `Socket:bio_drain` and `Socket:poll_wait` accepted an
optional `sec` argument but passed a nil deadline to their cores, which
dereferenced it unconditionally after EAGAIN.  On a non-blocking socket
EAGAIN is a normal condition, so any caller omitting the timeout got an
`attempt to index a nil value` error instead of waiting.

The public wrappers now always materialize a deadline from rcvtimeo,
sndtimeo or the default max timeout according to the I/O direction,
while the cores keep using the caller's deadline object as-is so read,
write and handshake continue to share a single timeout budget.

Adds regression tests for the three helpers without `sec`, using a
stubbed `tls_bio` to make EAGAIN deterministic and to assert that the
remaining deadline is passed to the wait call.
