### PR TITLE
Fix syncwrite to return nil len when lock acquisition fails

### DIFF
--- a/doc/net_socket.md
+++ b/doc/net_socket.md
@@ -454,6 +454,7 @@ call the function with `self` and passed arguments after acquiring the write loc
 
 **NOTE:** the write lock is released even if `fn` raises an error; the error
 message with stack traceback is returned as `err` instead of being thrown.
+`len` is `nil` whenever the lock cannot be acquired or `fn` raises an error.
 
 
 ## len, err, timeout = sock:write( str )

--- a/net.lua
+++ b/net.lua
@@ -583,19 +583,22 @@ function Socket:syncwrite(fn, ...)
     -- wait until another coroutine releases the right to write
     local fd = self.sock:fd()
     local ok, err, timeout = write_lock(fd, self.snddeadl)
-    local len = 0
 
     if ok then
         -- unlock even if fn raises an error, otherwise the fd is locked
         -- forever and subsequent synchronized writes wait indefinitely
+        local len
         ok, len, err, timeout = xpcall(fn, traceback, self, ...)
         write_unlock(fd)
         if not ok then
             return nil, len
         end
+        return len, err, timeout
     end
 
-    return len, err, timeout
+    -- 0 is truthy in Lua; returning it with an error would let callers
+    -- mistake the lock failure for a successful zero-byte write
+    return nil, err, timeout
 end
 
 --- write

--- a/test/stream/inet_test.lua
+++ b/test/stream/inet_test.lua
@@ -281,3 +281,14 @@ function testcase.syncread_syncwrite_lock_unsupported()
     assert.is_false(executed)
     assert.not_nil(error.is(werr, errno.ENOTSUP))
 end
+
+function testcase.syncwrite_lock_error_returns_nil_len()
+    local _, c = open_pair()
+    -- when the write lock cannot be acquired, len must be nil so that
+    -- callers cannot mistake the truthy 0 for success
+    local len, err = c:syncwrite(function()
+        error('must not be called')
+    end)
+    assert.is_nil(len)
+    assert.not_nil(error.is(err, errno.ENOTSUP))
+end


### PR DESCRIPTION
The len return value represents the result of an actual write attempt:
write_lua/send_lua return 0 when the underlying write(2) or send(2)
was invoked but wrote no bytes due to EAGAIN or EINTR.

syncwrite returned len = 0 even though fn never ran because the write
lock could not be acquired, which conflates "attempted a write that
wrote nothing" with "no write was attempted at all". Return nil as
syncread already does on lock acquisition failure.
