### PR TITLE
Suppress SIGPIPE on all socket write paths

### DIFF
--- a/doc/net_socket.md
+++ b/doc/net_socket.md
@@ -473,6 +473,11 @@ write a message to a socket.
 
 **NOTE:** all return values will be nil if closed by peer.
 
+**NOTE:** every write path (`write`, `send`, `sendmsg`, `sendfd`,
+`sendfile` and the TLS drain) suppresses `SIGPIPE` in-process; a write to
+a peer-closed stream socket returns the `EPIPE` error object instead of
+killing the process (see [net.socket](socket.md) for the platform notes).
+
 
 ## len, err, timeout = sock:writesync( str )
 

--- a/doc/socket.md
+++ b/doc/socket.md
@@ -9,11 +9,21 @@ that silently ignores unknown keys, so the same opts table can be reused
 across layers (for example the addrinfo resolver + the setsockopt pass
 that `bind_inet` runs internally).
 
+Every socket created or adopted by this module suppresses `SIGPIPE` on
+its own: writes to a peer-closed stream socket raise the `EPIPE` error
+object instead of killing the process, regardless of the host
+application's signal disposition.  On Linux this is done with the
+per-call `MSG_NOSIGNAL` flag; on macOS/BSD the `SO_NOSIGPIPE` socket
+option is applied at construction time.  Platforms providing neither
+mechanism (e.g. OpenBSD) cannot suppress the signal in-process; hosts
+there must ignore `SIGPIPE` themselves.
+
 
 ## sock, err = socket.wrap( fd )
 
 wrap an existing socket file descriptor into a `net.socket` userdata.
-`FD_CLOEXEC` and `O_NONBLOCK` are set on the descriptor as a side effect.
+`FD_CLOEXEC`, `O_NONBLOCK` and `SO_NOSIGPIPE` (where available) are set
+on the descriptor as a side effect.
 
 **Parameters**
 

--- a/src/socket.c
+++ b/src/socket.c
@@ -86,10 +86,25 @@ static inline int set_nonblock(int fd)
     return set_fd_flag(fd, F_GETFL, F_SETFL, O_NONBLOCK);
 }
 
-// set cloexec + nonblock on fd; return 0 on success, -1 on error
-static inline int set_cloexec_nonblock(int fd)
+// set SO_NOSIGPIPE on fd; return 0 on success, -1 on error
+static inline int set_nosigpipe(int fd)
 {
-    return (set_cloexec(fd) == -1 || set_nonblock(fd) == -1) ? -1 : 0;
+#if defined(SO_NOSIGPIPE)
+    int on = 1;
+    return setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &on, sizeof(on));
+#else
+    (void)fd;
+    return 0;
+#endif
+}
+
+// set cloexec + nonblock + nosigpipe on fd; return 0 on success, -1 on error
+static inline int set_cloexec_nonblock_nosigpipe(int fd)
+{
+    return (set_cloexec(fd) == -1 || set_nonblock(fd) == -1 ||
+            set_nosigpipe(fd) == -1) ?
+               -1 :
+               0;
 }
 
 static int cloexec_nonblock_lua(lua_State *L, const char *op, int getfl,
@@ -1142,15 +1157,23 @@ static inline int acceptfd(int sfd, struct sockaddr *addr, socklen_t *addrlen)
 
     if (flg != -1) {
 #if defined(HAVE_ACCEPT4)
-        flg = SOCK_CLOEXEC | ((flg & O_NONBLOCK) ? SOCK_NONBLOCK : 0);
-        return accept4(sfd, addr, addrlen, flg);
+        flg     = SOCK_CLOEXEC | ((flg & O_NONBLOCK) ? SOCK_NONBLOCK : 0);
+        int nfd = accept4(sfd, addr, addrlen, flg);
+
+        if (nfd != -1) {
+            if (set_nosigpipe(nfd) == 0) {
+                return nfd;
+            }
+            close(nfd);
+        }
 
 #else
         int fd = accept(sfd, addr, addrlen);
 
         if (fd != -1) {
-            // set close-on-exec and server socket flags
-            if (set_cloexec(fd) == 0 && fcntl(fd, F_SETFL, flg) == 0) {
+            // set close-on-exec, server socket flags and SIGPIPE suppression
+            if (set_cloexec(fd) == 0 && fcntl(fd, F_SETFL, flg) == 0 &&
+                set_nosigpipe(fd) == 0) {
                 return fd;
             }
             close(fd);
@@ -1282,6 +1305,13 @@ static int net_check_msgflags(lua_State *L, int startidx)
     return flg;
 }
 
+// per-call SIGPIPE suppression for send(2)-family calls.  On platforms
+// without MSG_NOSIGNAL this expands to 0 and suppression relies on the
+// SO_NOSIGPIPE socket option applied at construction time instead.
+#ifndef MSG_NOSIGNAL
+# define MSG_NOSIGNAL 0
+#endif
+
 static int send_lua(lua_State *L)
 {
     net_socket_t *s = lauxh_checkudata(L, 1, SOCKET_MT);
@@ -1298,7 +1328,7 @@ static int send_lua(lua_State *L)
         return 2;
     }
 
-    rv = send(s->fd, buf, len, flg);
+    rv = send(s->fd, buf, len, flg | MSG_NOSIGNAL);
     switch (rv) {
     case -1:
         if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
@@ -1339,8 +1369,8 @@ static int sendto_lua(lua_State *L)
         return 2;
     }
 
-    rv = sendto(s->fd, buf, len, flg, (const struct sockaddr *)info->ai.ai_addr,
-                info->ai.ai_addrlen);
+    rv = sendto(s->fd, buf, len, flg | MSG_NOSIGNAL,
+                (const struct sockaddr *)info->ai.ai_addr, info->ai.ai_addrlen);
     switch (rv) {
     case -1:
         if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
@@ -1404,7 +1434,7 @@ static int sendfd_lua(lua_State *L)
         data.msg_namelen = info->ai.ai_addrlen;
     }
 
-    switch (sendmsg(s->fd, &data, flg)) {
+    switch (sendmsg(s->fd, &data, flg | MSG_NOSIGNAL)) {
     case -1:
         if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
             // again
@@ -1483,7 +1513,7 @@ static int sendmsg_lua(lua_State *L)
         return 2;
     }
 
-    rv = sendmsg(s->fd, &data, flgs);
+    rv = sendmsg(s->fd, &data, flgs | MSG_NOSIGNAL);
     if (rv == -1) {
         int err = errno;
         lua_settop(L, 0);
@@ -1686,7 +1716,7 @@ static int sendfile_lua(lua_State *L)
         return 2;
     }
 
-    nbytes = send(s->fd, buf, nbytes, 0);
+    nbytes = send(s->fd, buf, nbytes, MSG_NOSIGNAL);
     switch (nbytes) {
     case -1:
         if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
@@ -2036,7 +2066,10 @@ static int write_lua(lua_State *L)
         return 2;
     }
 
-    rv = write(s->fd, buf, len);
+    // write(2) equivalent for sockets that never raises SIGPIPE on platforms
+    // with per-call suppression.  send(fd, buf, len, 0) is equivalent to
+    // write(fd, buf, len) on sockets, so only the flags differ.
+    rv = send(s->fd, buf, len, MSG_NOSIGNAL);
     switch (rv) {
     case -1:
         if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
@@ -2412,7 +2445,7 @@ static int wrap_lua(lua_State *L)
         lua_pushnil(L);
         lua_errno_new(L, errno, "getsockopt");
         return 2;
-    } else if (set_cloexec_nonblock(fd) == -1) {
+    } else if (set_cloexec_nonblock_nosigpipe(fd) == -1) {
         lua_pushnil(L);
         lua_errno_new(L, errno, "fcntl");
         return 2;
@@ -2580,10 +2613,10 @@ static int pair_lua(lua_State *L)
         return 2;
     }
 
-    // set FD_CLOEXEC and O_NONBLOCK on both fds, closing both fds and returning
-    // an error if either fcntl() fails.
+    // set FD_CLOEXEC, O_NONBLOCK and SIGPIPE suppression on both fds, closing
+    // both fds and returning an error if any of them fails.
     for (int i = 0; i < 2; i++) {
-        if (set_cloexec_nonblock(fds[i]) == -1) {
+        if (set_cloexec_nonblock_nosigpipe(fds[i]) == -1) {
             int err = errno;
             close(fds[0]);
             close(fds[1]);
@@ -2639,10 +2672,10 @@ static net_socket_t *new_socket(lua_State *L, so_config_t *cfg)
     s->gc_thread_ref = lauxh_ref(L);
     lauxh_setmetatable(L, SOCKET_MT);
 
-    if (set_cloexec_nonblock(s->fd) == -1 ||
+    if (set_cloexec_nonblock_nosigpipe(s->fd) == -1 ||
         sockopts_apply(s->fd, s->family, &cfg->opts) != 0) {
-        // set_cloexec_nonblock failed, close the socket and return the error to
-        // the callback
+        // set_cloexec_nonblock_nosigpipe failed, close the socket and return
+        // the error to the callback
         int err = errno;
         close(s->fd);
         s->fd = -1;

--- a/src/tls_bio.c
+++ b/src/tls_bio.c
@@ -23,6 +23,7 @@
 #include <errno.h>
 #include <pthread.h>
 #include <stdio.h>
+#include <sys/socket.h>
 
 #include "lua_errno.h"
 
@@ -207,8 +208,8 @@ static int consume_lua(lua_State *L)
         // Lua 5.3+ and routing through luaL_error would parse the string
         // twice.  64 bytes covers "consume(-9223372036854775808)" comfortably.
         char buf[64];
-        int len = snprintf(buf, sizeof(buf),
-                           "consume(%lld): out of range", (long long)n);
+        int len = snprintf(buf, sizeof(buf), "consume(%lld): out of range",
+                           (long long)n);
         lua_pushlstring(L, buf, (size_t)len);
         return lua_error(L);
     }
@@ -268,7 +269,12 @@ RETRY:
         return 1;
     }
 
-    n = write(bio->fd, data, len);
+    // never raise SIGPIPE; send(fd, buf, len, 0) is equivalent to write()
+#ifndef MSG_NOSIGNAL
+# define MSG_NOSIGNAL 0
+#endif
+
+    n = send(bio->fd, data, len, MSG_NOSIGNAL);
     switch (n) {
     case -1:
         if (errno == EINTR) {
@@ -318,8 +324,8 @@ static int commit_lua(lua_State *L)
         // Lua 5.3+ and routing through luaL_error would parse the string
         // twice.  64 bytes covers "commit(-9223372036854775808)" comfortably.
         char buf[64];
-        int len = snprintf(buf, sizeof(buf),
-                           "commit(%lld): out of range", (long long)n);
+        int len = snprintf(buf, sizeof(buf), "commit(%lld): out of range",
+                           (long long)n);
         lua_pushlstring(L, buf, (size_t)len);
         return lua_error(L);
     }

--- a/test/socket_test.lua
+++ b/test/socket_test.lua
@@ -1,6 +1,8 @@
 local fileno = require('io.fileno')
 local testcase = require('testcase')
 local timer = require('testcase.timer')
+local fork = require('testcase.fork')
+local signal = require('testcase.signal')
 local assert = require('assert')
 local errno = require('errno')
 local addrinfo = require('net.addrinfo')
@@ -3366,6 +3368,69 @@ function testcase.sendmsg_when_peer_closed()
     a:close()
 end
 
+function testcase.send_survives_sigpipe_after_shutdown_wr()
+    -- Writing after the local write direction is shut down must surface
+    -- EPIPE as a Lua error object, not kill the process with SIGPIPE.
+    -- The child runs with SIGPIPE at its default disposition so the
+    -- runner's SIGPIPE ignore cannot mask the behaviour; the parent
+    -- detects a SIGPIPE death via the wait status.
+    local proc = assert(fork())
+    if proc:is_child() then
+        signal.sigdefault('SIGPIPE')
+        local socks = assert(socket.pair({
+            socktype = 'stream',
+        }))
+        assert(socks[1]:shutdown('wr'))
+        local sent, err = socks[1]:send('x')
+        assert.is_nil(sent)
+        assert.match(err, 'EPIPE')
+        os.exit(0)
+    end
+    local stat = assert(proc:wait())
+    assert.is_nil(stat.sigterm)
+    assert.equal(stat.exit, 0)
+end
+
+function testcase.write_survives_sigpipe_after_shutdown_wr()
+    -- Same as send_survives_sigpipe_after_shutdown_wr, but through the
+    -- plain write() path.
+    local proc = assert(fork())
+    if proc:is_child() then
+        signal.sigdefault('SIGPIPE')
+        local socks = assert(socket.pair({
+            socktype = 'stream',
+        }))
+        assert(socks[1]:shutdown('wr'))
+        local n, err = socks[1]:write('x')
+        assert.is_nil(n)
+        assert.match(err, 'EPIPE')
+        os.exit(0)
+    end
+    local stat = assert(proc:wait())
+    assert.is_nil(stat.sigterm)
+    assert.equal(stat.exit, 0)
+end
+
+function testcase.sendmsg_survives_sigpipe_after_shutdown_wr()
+    -- Same as send_survives_sigpipe_after_shutdown_wr, but through the
+    -- sendmsg() path.
+    local proc = assert(fork())
+    if proc:is_child() then
+        signal.sigdefault('SIGPIPE')
+        local socks = assert(socket.pair({
+            socktype = 'stream',
+        }))
+        assert(socks[1]:shutdown('wr'))
+        local sent, err = socks[1]:sendmsg('x')
+        assert.is_nil(sent)
+        assert.match(err, 'EPIPE')
+        os.exit(0)
+    end
+    local stat = assert(proc:wait())
+    assert.is_nil(stat.sigterm)
+    assert.equal(stat.exit, 0)
+end
+
 function testcase.sendmsg_again()
     -- sendmsg() surfaces EAGAIN via (0, nil, true) once the send buffer
     -- is full.  We shrink the buffer to drive the branch quickly.
@@ -4550,6 +4615,29 @@ function testcase.wrap_sets_cloexec_and_nonblock()
                    'wrap() must re-apply O_NONBLOCK to the adopted fd')
     wrapped:close()
 end
+
+function testcase.wrap_send_survives_sigpipe_after_shutdown_wr()
+    -- Sockets re-adopted via wrap() must get the same SIGPIPE suppression
+    -- as freshly created ones.
+    local proc = assert(fork())
+    if proc:is_child() then
+        signal.sigdefault('SIGPIPE')
+        local socks = assert(socket.pair({
+            socktype = 'stream',
+        }))
+        local fd = assert(socks[1]:unwrap())
+        local s = assert(socket.wrap(fd))
+        assert(s:shutdown('wr'))
+        local sent, err = s:send('x')
+        assert.is_nil(sent)
+        assert.match(err, 'EPIPE')
+        os.exit(0)
+    end
+    local stat = assert(proc:wait())
+    assert.is_nil(stat.sigterm)
+    assert.equal(stat.exit, 0)
+end
+
 function testcase.unwrap_returns_fd_and_disables_socket()
     -- Explicitly exercise unwrap_lua's success path to ensure gc_thread is
     -- released and the fd is transferred back to the caller.
@@ -4820,6 +4908,37 @@ function testcase.acceptfd_on_closed_socket()
     local rv, err = s:acceptfd()
     assert.is_nil(rv)
     assert(err)
+end
+
+function testcase.accept_send_survives_sigpipe_after_shutdown_wr()
+    -- Sockets obtained via accept() must be as SIGPIPE-safe as paired
+    -- ones.
+    local proc = assert(fork())
+    if proc:is_child() then
+        signal.sigdefault('SIGPIPE')
+        local server = assert(socket.bind_inet('127.0.0.1', 0, {
+            socktype = 'stream',
+            protocol = 'tcp',
+            reuseaddr = true,
+        }))
+        assert(server:listen())
+        local ai = assert(server:getsockname())
+        local client = assert(socket.connect_inet('127.0.0.1', ai:port(), {
+            socktype = 'stream',
+            protocol = 'tcp',
+        }))
+        assert(server:recvable(1))
+        local peer = assert(server:accept())
+        client:close()
+        assert(peer:shutdown('wr'))
+        local sent, err = peer:send('x')
+        assert.is_nil(sent)
+        assert.match(err, 'EPIPE')
+        os.exit(0)
+    end
+    local stat = assert(proc:wait())
+    assert.is_nil(stat.sigterm)
+    assert.equal(stat.exit, 0)
 end
 
 function testcase.sendable_recvable_basic()

--- a/test/tls/context_test.lua
+++ b/test/tls/context_test.lua
@@ -1,5 +1,7 @@
 require('luacov')
 local testcase = require('testcase')
+local fork = require('testcase.fork')
+local signal = require('testcase.signal')
 local assert = require('assert')
 local errno = require('errno')
 local exec = require('exec').execvp
@@ -1078,7 +1080,8 @@ function testcase.accept_s_client_tls13_ciphersuite_rejected()
     local ep = new_ep(ctx, 'server', fd)
 
     local ok = handshake(ep)
-    assert.is_false(ok, 'handshake must fail with an out-of-policy TLS 1.3 suite')
+    assert.is_false(ok,
+                    'handshake must fail with an out-of-policy TLS 1.3 suite')
 
     for _, s in ipairs(socks) do
         s:close()
@@ -1103,7 +1106,8 @@ function testcase.connect_s_server_tls13_ciphersuite_rejected()
     local ep = new_ep(ctx, 'client', fd)
 
     local ok = handshake(ep)
-    assert.is_false(ok, 'handshake must fail with an out-of-policy TLS 1.3 suite')
+    assert.is_false(ok,
+                    'handshake must fail with an out-of-policy TLS 1.3 suite')
 
     for _, s in ipairs(socks) do
         s:close()
@@ -1605,6 +1609,40 @@ function testcase.bio_peek_returns_data_after_ssl_write()
     assert(close_ep(ep))
     csock:close()
     proc:close()
+end
+
+function testcase.drain_survives_sigpipe_after_shutdown_wr()
+    -- Draining the TX ring after the local write direction is shut down
+    -- must surface EPIPE as a Lua error object, not kill the process with
+    -- SIGPIPE.  The child runs with SIGPIPE at its default disposition so
+    -- the runner's SIGPIPE ignore cannot mask the behaviour; the parent
+    -- detects a SIGPIPE death via the wait status.
+    local proc = assert(fork())
+    if proc:is_child() then
+        signal.sigdefault('SIGPIPE')
+
+        -- the first handshake call emits the ClientHello into the TX ring
+        -- and then reports WANT_READ; shutting down the write direction
+        -- makes the subsequent drain() fail deterministically
+        local socks = assert(socket.pair({
+            socktype = 'stream',
+        }))
+        local client = assert(new_tls_client())
+        local ctx = assert(tls_context.connect(client, socks[1]:fd(), nil, true,
+                                               false, true, true, 1))
+        local bio = assert(ctx:get_bio())
+        local ok = ctx:handshake()
+        assert(not ok, 'handshake must not complete without a TLS peer')
+
+        assert(socks[1]:shutdown('wr'))
+        local n, derr = bio:drain()
+        assert.is_nil(n)
+        assert.match(derr, 'EPIPE')
+        os.exit(0)
+    end
+    local stat = assert(proc:wait())
+    assert.is_nil(stat.sigterm)
+    assert.equal(stat.exit, 0)
 end
 
 function testcase.bio_space_returns_nil_when_rxbuf_full()


### PR DESCRIPTION
Writing to a peer-closed or locally shutdown socket raised SIGPIPE
and killed the process unless the host application ignored the
signal. Every send(2)-family call now passes MSG_NOSIGNAL, the
write(2) paths use the equivalent send(fd, buf, len, MSG_NOSIGNAL),
and sockets from socket(), accept(), socketpair() and wrap() set
SO_NOSIGPIPE where available, so a broken pipe always surfaces as
the EPIPE error object instead.