### PR TITLE
Fix ALPN validation to enforce RFC 7301 list limit

### DIFF
--- a/src/tls.h
+++ b/src/tls.h
@@ -65,8 +65,9 @@ typedef struct {
 // invalid input (non-string element, >255 bytes).
 static inline int tls_check_alpn_table(lua_State *L, int idx)
 {
-    int n      = 0;
-    int nproto = 0;
+    int n         = 0;
+    int nproto    = 0;
+    size_t wtotal = 0;
 
     // check if the table is nil or empty
     if (lua_isnoneornil(L, idx)) {
@@ -109,6 +110,18 @@ static inline int tls_check_alpn_table(lua_State *L, int idx)
             // ignore empty protocol strings
             lua_pop(L, 1);
             continue;
+        }
+
+        // RFC 7301 encodes the ProtocolNameList with a 2-byte length, so
+        // the wire format must not exceed 65535 bytes in total.  This also
+        // keeps the size_t-to-unsigned int cast at the
+        // SSL_CTX_set_alpn_protos() call sites free of truncation.
+        wtotal += plen + 1;
+        if (wtotal > 0xffff) {
+            lua_pop(L, 1);
+            lua_pushfstring(
+                L, "total length of alpn protocols exceeds 65535 bytes");
+            return -1;
         }
 
         // alpn wire format: [len][name]

--- a/src/tls_context.c
+++ b/src/tls_context.c
@@ -43,8 +43,8 @@
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 #include <openssl/x509_vfy.h>
-#include <stdio.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <sys/types.h>
 
 static int handshake_bio_lua(lua_State *L, tls_ctx_t *ctx)
@@ -289,8 +289,8 @@ static int read_lua(lua_State *L)
         return 2;
     }
 
-    // bufsiz <= 0 is a special case that means "use a reasonable default buffer
-    // size"
+    // bufsiz < 0 means "use the default buffer size"
+    // bufsiz == 0 is passed through to SSL_read()
     if (bufsiz < 0) {
         bufsiz = BUFSIZ;
     } else if ((uint64_t)bufsiz > (uint64_t)INT_MAX) {

--- a/test/tls/context_test.lua
+++ b/test/tls/context_test.lua
@@ -1151,6 +1151,33 @@ function testcase.new_client_alpn_invalid()
     assert(err, 'should return error')
 end
 
+function testcase.new_client_alpn_total_length_invalid()
+    -- RFC 7301 limits the wire-format ProtocolNameList to 65535 bytes;
+    -- each element contributes 1 length byte plus its name, so a list of
+    -- 256 elements x 255-byte names reaches 65536 bytes and must be
+    -- rejected before it reaches OpenSSL.
+    local protos = {}
+    for i = 1, 256 do
+        protos[i] = string.rep('x', 255)
+    end
+    local ctx, err = new_tls_client('default', 'default', protos)
+    assert(ctx == nil, 'should reject >65535 byte ALPN list')
+    assert(err, 'should return error')
+end
+
+function testcase.new_client_alpn_total_length_at_limit()
+    -- A list whose wire format totals exactly 65535 bytes stays within
+    -- the RFC 7301 limit and must be accepted: 255 elements x 256 bytes
+    -- (1 length byte + 255-byte name) plus one 254-byte name.
+    local protos = {}
+    for i = 1, 255 do
+        protos[i] = string.rep('x', 255)
+    end
+    protos[256] = string.rep('y', 254)
+    local ctx, err = new_tls_client('default', 'default', protos)
+    assert(ctx, err)
+end
+
 function testcase.connect_requires_servername_when_full_verify()
     -- Full verification without a servername has no identity to match
     -- against the peer certificate, so connect must refuse to proceed.


### PR DESCRIPTION
Each protocol name is already checked against the 255-byte
ProtocolName limit, but the wire-format ProtocolNameList is bounded
by a 2-byte length (65535 bytes) and long lists passed that limit
unchecked. Reject lists whose wire format exceeds 65535 bytes.