### PR TITLE
Move prefer_client_ciphers from TLS client to server

### DIFF
--- a/doc/net_stream_inet_client.md
+++ b/doc/net_stream_inet_client.md
@@ -31,7 +31,6 @@ if the `tlscfg` option is specified, it returns [net.tls.stream.inet.Client](net
         - `alpn:table?`: array of protocol name strings for ALPN (Application-Layer Protocol Negotiation). (default is `nil`)
         - `session_cache_timeout:integer?`: session cache timeout seconds. (default is `0` that cache is disabled)
         - `session_cache_size:integer?`: session cache size. (default is `SSL_SESSION_CACHE_MAX_SIZE_DEFAULT`)
-        - `prefer_client_ciphers:boolean?`: prefer client cipher suites over server cipher suites. (default is `false`)
         - `ocsp_error_callback:function?`: callback function that called when an error occurred in OCSP verification. (default is `nil`)
         - `noverify_name:boolean?`: disable verification of the subject name of the server certificate. (default is `false`)
         - `noverify_time:boolean?`: disable verification of the server certificate expiration time. (default is `false`)

--- a/doc/net_stream_inet_server.md
+++ b/doc/net_stream_inet_server.md
@@ -35,6 +35,7 @@ if the `tlscfg` option is specified, it returns [net.tls.stream.inet.Server](net
         - `alpn:table?`: array of protocol name strings for ALPN (Application-Layer Protocol Negotiation). (default is `nil`)
         - `session_cache_timeout:integer?`: session cache timeout seconds. (default is `0` that cache is disabled)
         - `session_cache_size:integer?`: session cache size. (default is `SSL_SESSION_CACHE_MAX_SIZE_DEFAULT`)
+        - `prefer_client_ciphers:boolean?`: prefer client cipher suites over server cipher suites. (default is `false`)
 
 **Returns**
 

--- a/doc/net_stream_unix_client.md
+++ b/doc/net_stream_unix_client.md
@@ -30,7 +30,6 @@ if the `tlscfg` option is specified, it returns [net.tls.stream.unix.Client](net
         - `alpn:table?`: array of protocol name strings for ALPN (Application-Layer Protocol Negotiation). (default is `nil`)
         - `session_cache_timeout:integer?`: session cache timeout seconds. (default is `0` that cache is disabled)
         - `session_cache_size:integer?`: session cache size. (default is `SSL_SESSION_CACHE_MAX_SIZE_DEFAULT`)
-        - `prefer_client_ciphers:boolean?`: prefer client cipher suites over server cipher suites. (default is `false`)
         - `ocsp_error_callback:function?`: callback function that called when an error occurred in OCSP verification. (default is `nil`)
         - `noverify_name:boolean?`: disable verification of the subject name of the server certificate. (default is `false`)
         - `noverify_time:boolean?`: disable verification of the server certificate expiration time. (default is `false`)

--- a/doc/net_stream_unix_server.md
+++ b/doc/net_stream_unix_server.md
@@ -30,6 +30,7 @@ if the `tlscfg` option is specified, it returns [net.tls.stream.unix.Server](net
     - `alpn:table?`: array of protocol name strings for ALPN (Application-Layer Protocol Negotiation). (default is `nil`)
     - `session_cache_timeout:integer?`: session cache timeout seconds. (default is `0` that cache is disabled)
     - `session_cache_size:integer?`: session cache size. (default is `SSL_SESSION_CACHE_MAX_SIZE_DEFAULT`)
+    - `prefer_client_ciphers:boolean?`: prefer client cipher suites over server cipher suites. (default is `false`)
     
 **Returns**
 

--- a/lib/stream/inet.lua
+++ b/lib/stream/inet.lua
@@ -148,7 +148,6 @@ local function new_client(host, port, opts)
                                     opts.tlscfg.alpn,
                                     opts.tlscfg.session_cache_timeout,
                                     opts.tlscfg.session_cache_size,
-                                    opts.tlscfg.prefer_client_ciphers,
                                     opts.tlscfg.ocsp_error_callback)
         if err then
             return nil, err
@@ -204,7 +203,8 @@ local function new_server(host, port, opts)
                                     opts.tlscfg.protocol, opts.tlscfg.ciphers,
                                     opts.tlscfg.alpn,
                                     opts.tlscfg.session_timeout,
-                                    opts.tlscfg.session_cache_size)
+                                    opts.tlscfg.session_cache_size,
+                                    opts.tlscfg.prefer_client_ciphers)
         if err then
             return nil, err
         end

--- a/lib/stream/unix.lua
+++ b/lib/stream/unix.lua
@@ -133,7 +133,6 @@ local function new_client(pathname, opts)
                                     opts.tlscfg.alpn,
                                     opts.tlscfg.session_cache_timeout,
                                     opts.tlscfg.session_cache_size,
-                                    opts.tlscfg.prefer_client_ciphers,
                                     opts.tlscfg.ocsp_error_callback)
         if err then
             return nil, err
@@ -180,7 +179,8 @@ local function new_server(pathname, tlscfg)
         local ctx, err = tls_server(tlscfg.cert, tlscfg.key, tlscfg.protocol,
                                     tlscfg.ciphers, tlscfg.alpn,
                                     tlscfg.session_timeout,
-                                    tlscfg.session_cache_size)
+                                    tlscfg.session_cache_size,
+                                    tlscfg.prefer_client_ciphers)
         if err then
             return nil, err
         end

--- a/src/tls_client.c
+++ b/src/tls_client.c
@@ -28,6 +28,7 @@
 // lua
 #include <lauxlib.h>
 // system
+#include <limits.h>
 #include <openssl/asn1.h>
 #include <openssl/bio.h>
 #include <openssl/err.h>
@@ -38,7 +39,6 @@
 #include <openssl/x509.h>
 #include <openssl/x509_vfy.h>
 #include <openssl/x509v3.h>
-#include <limits.h>
 #include <stdio.h>
 
 // set callback for ALPN (Application-Layer Protocol Negotiation) support
@@ -362,11 +362,10 @@ static int new_lua(lua_State *L)
     int cipher        = luaL_checkoption(L, 2, "default", TLS_CIPHER_SUITES);
     int cache_timeout = lauxh_optinteger(L, 4, 0);
     int cache_size = lauxh_optinteger(L, 5, SSL_SESSION_CACHE_MAX_SIZE_DEFAULT);
-    int prefer_client_ciphers = lauxh_optboolean(L, 6, 0);
-    int nalpn                 = 0;
-    tls_client_t *c           = NULL;
-    const char *errop         = NULL;
-    const char *errmsg        = NULL;
+    int nalpn      = 0;
+    tls_client_t *c    = NULL;
+    const char *errop  = NULL;
+    const char *errmsg = NULL;
 
     // check ALPN table parsing error
     nalpn = tls_check_alpn_table(L, 3);
@@ -377,9 +376,9 @@ static int new_lua(lua_State *L)
     }
 
     // check error function
-    if (narg >= 7 && !lua_isnoneornil(L, 7)) {
-        luaL_checktype(L, 7, LUA_TFUNCTION);
-        lua_settop(L, 7);
+    if (narg >= 6 && !lua_isnoneornil(L, 6)) {
+        luaL_checktype(L, 6, LUA_TFUNCTION);
+        lua_settop(L, 6);
     }
 
     // create context
@@ -428,11 +427,6 @@ static int new_lua(lua_State *L)
         SSL_CTX_set_num_tickets(c->ctx, 2);
     }
 
-    // prefer client cipher suites over server cipher suites
-    if (prefer_client_ciphers != 1) {
-        SSL_CTX_set_options(c->ctx, SSL_OP_CIPHER_SERVER_PREFERENCE);
-    }
-
     // set default verify certificate locations
     if (SSL_CTX_set_default_verify_paths(c->ctx) != 1) {
         errop  = "SSL_CTX_set_default_verify_paths";
@@ -460,8 +454,8 @@ static int new_lua(lua_State *L)
     }
 
     // keep error function reference
-    if (narg >= 7) {
-        c->error_cb_ref = lauxh_refat(L, 7);
+    if (narg >= 6) {
+        c->error_cb_ref = lauxh_refat(L, 6);
     }
 
     // return net.tls.client userdata

--- a/src/tls_server.c
+++ b/src/tls_server.c
@@ -173,11 +173,12 @@ static int new_lua(lua_State *L)
     int protocol     = luaL_checkoption(L, 3, "default", TLS_PROTOCOLS);
     int cipher_suite = luaL_checkoption(L, 4, "default", TLS_CIPHER_SUITES);
     int nalpn        = 0;
-    lua_Integer sess_timout = luaL_optinteger(L, 6, 300);
-    lua_Integer sess_cache  = luaL_optinteger(L, 7, 1024 * 20);
-    tls_server_t *s         = NULL;
-    const char *errop       = NULL;
-    const char *errmsg      = NULL;
+    lua_Integer sess_timout   = luaL_optinteger(L, 6, 300);
+    lua_Integer sess_cache    = luaL_optinteger(L, 7, 1024 * 20);
+    int prefer_client_ciphers = lauxh_optboolean(L, 8, 0);
+    tls_server_t *s           = NULL;
+    const char *errop         = NULL;
+    const char *errmsg        = NULL;
 
     // check ALPN table argument
     nalpn = tls_check_alpn_table(L, 5);
@@ -253,7 +254,9 @@ static int new_lua(lua_State *L)
     // set session configuration
     set_session_conf(s->ctx, sess_timout, sess_cache);
     // prefer server cipher suites over client cipher suites
-    SSL_CTX_set_options(s->ctx, SSL_OP_CIPHER_SERVER_PREFERENCE);
+    if (!prefer_client_ciphers) {
+        SSL_CTX_set_options(s->ctx, SSL_OP_CIPHER_SERVER_PREFERENCE);
+    }
 
     // configure ALPN (Application-Layer Protocol Negotiation)
     if (nalpn > 0) {

--- a/test/tls/context_test.lua
+++ b/test/tls/context_test.lua
@@ -995,7 +995,7 @@ function testcase.connect_s_server_alpn()
 
     local client = assert(new_tls_client('default', 'default', {
         'h2',
-    }, 0, 0, false))
+    }, 0, 0))
     local ctx = assert(tls_context.connect(client, fd, nil, true, false, true,
                                            false))
     local ep = new_ep(ctx, 'client', fd)
@@ -1113,6 +1113,73 @@ function testcase.connect_s_server_tls13_ciphersuite_rejected()
         s:close()
     end
     proc:close()
+end
+
+function testcase.new_server_cipher_preference()
+    -- TLS 1.2 cipher preference: the client offers AES128-SHA256 before
+    -- AES256-SHA384, while the 'default' server policy (HIGH:!aNULL) ranks
+    -- AES256-SHA384 first. Default keeps SSL_OP_CIPHER_SERVER_PREFERENCE
+    -- (server order wins); prefer_client_ciphers = true drops the option
+    -- (client order wins).
+    local selected_cipher = function(prefer_client)
+        local lsock = assert(socket.bind_inet('127.0.0.1', 0, {
+            socktype = 'stream',
+            protocol = 'tcp',
+            reuseaddr = true,
+            reuseport = true,
+        }))
+        local socks = {
+            lsock,
+        }
+        assert(lsock:listen())
+        local port = assert(lsock:getsockname()):port()
+
+        local proc = exec('openssl', {
+            's_client',
+            '-connect',
+            '127.0.0.1:' .. tostring(port),
+            '-brief',
+            '-noservername',
+            '-tls1_2',
+            '-cipher',
+            'ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384',
+        })
+        assert(gpoll.wait_readable(lsock:fd(), DEADLINE))
+        local afd = assert(lsock:acceptfd())
+        -- Keep the wrapper alive so its __gc does not close the fd while
+        -- the TLS context still uses it.
+        local asock = assert(socket.wrap(afd))
+        socks[#socks + 1] = asock
+        local fd = asock:fd()
+
+        local server = assert(new_tls_server(SERVER_CONFIG.cert,
+                                             SERVER_CONFIG.key, 'tlsv1.2',
+                                             'default', nil, 300, 128,
+                                             prefer_client))
+        local ctx = assert(tls_context.accept(server, fd, false))
+        local ep = new_ep(ctx, 'server', fd)
+        assert(handshake(ep))
+
+        -- s_client -brief prints the negotiated suite on stderr.
+        local selected
+        for line in proc.stderr:lines() do
+            selected = line:match('^Ciphersuite:%s+(%S+)')
+            if selected then
+                break
+            end
+        end
+        assert(close_ep(ep))
+        for _, s in ipairs(socks) do
+            s:close()
+        end
+        proc:close()
+        return selected
+    end
+
+    -- default: the server preference (AES256-SHA384 ranks first) wins.
+    assert.equal(selected_cipher(nil), 'ECDHE-RSA-AES256-SHA384')
+    -- prefer_client_ciphers = true: the client order wins.
+    assert.equal(selected_cipher(true), 'ECDHE-RSA-AES128-SHA256')
 end
 
 function testcase.new_server_alpn_invalid()
@@ -1379,12 +1446,12 @@ end
 
 function testcase.new_client_option_matrix()
     -- exercise the constructor's option branches that plain new_tls_client()
-    -- skips: non-default protocol, session cache enabled, prefer client
-    -- ciphers, ALPN list and error callback.
+    -- skips: non-default protocol, session cache enabled, ALPN list and error
+    -- callback.
     local ctx = assert(new_tls_client('tlsv1.2', 'default', {
         'h2',
         'http/1.1',
-    }, 300, 128, true, function()
+    }, 300, 128, function()
     end))
     assert.match(tostring(ctx), '^net.tls.client: ', false)
 


### PR DESCRIPTION
## Purpose

`SSL_OP_CIPHER_SERVER_PREFERENCE` only affects servers, so the `prefer_client_ciphers` option accepted by the TLS client constructor was a bug. This moves the option to `net.tls.server`, where it actually takes effect.

## Changes

- `net.tls.client.new`: remove the `prefer_client_ciphers` argument (6th); the OCSP error callback shifts to the 6th position
- `net.tls.server.new`: add `prefer_client_ciphers` as the 8th argument (non-breaking). Servers keep preferring their own cipher order by default and honor the client order when enabled
- `net.stream.inet` / `net.stream.unix`: client wrappers stop passing `tlscfg.prefer_client_ciphers`; server wrappers pass it
- Docs updated for both client and server `tlscfg` tables

## Compatibility

- Breaking for direct `net.tls.client.new` callers that passed a boolean as the 6th argument (now the OCSP callback slot)
- `tlscfg.prefer_client_ciphers` in client options is now ignored (no error)
- Server-side addition is backward compatible; default behavior is unchanged
