### PR TITLE
Fix size_t to int narrowing in TLS BIO bufcap

### DIFF
--- a/doc/net_tls.md
+++ b/doc/net_tls.md
@@ -22,4 +22,5 @@ policy.
 
 When `context.accept()` / `context.connect()` are called with `use_bio=true`,
 an optional trailing `bufcap` can be supplied. If omitted, or smaller than
-`context.encrypted_length(protocol)`, the minimum safe size is used.
+`context.encrypted_length(protocol)`, the minimum safe size is used. A `bufcap`
+that cannot be allocated is reported as an error from these functions.

--- a/src/tls_bio.c
+++ b/src/tls_bio.c
@@ -457,7 +457,7 @@ static int gc_lua(lua_State *L)
     return 0;
 }
 
-static inline int bio_buf_init(tls_bio_buf_t *b, int cap)
+static inline int bio_buf_init(tls_bio_buf_t *b, size_t cap)
 {
     b->mem = BUF_MEM_new();
     if (!b->mem) {
@@ -472,7 +472,7 @@ static inline int bio_buf_init(tls_bio_buf_t *b, int cap)
     return 0;
 }
 
-tls_bio_t *tls_bio_new(lua_State *L, int fd, int cap)
+tls_bio_t *tls_bio_new(lua_State *L, int fd, size_t cap)
 {
     tls_bio_t *bio = lua_newuserdata(L, sizeof(tls_bio_t));
 

--- a/src/tls_bio.h
+++ b/src/tls_bio.h
@@ -81,10 +81,11 @@ int tls_bio_setup(SSL *ssl, tls_bio_t *bio);
  * @param L   Lua state, used to allocate the userdata and register the
  *            metatable.
  * @param fd  Network socket file descriptor.
- * @param cap Capacity in bytes for both rx and tx buffers.
+ * @param cap Capacity in bytes for both rx and tx buffers; must be > 0.  An
+ *            unallocatable capacity yields NULL.
  * @return    Pointer to the allocated tls_bio_t on success, or NULL on failure.
  */
-tls_bio_t *tls_bio_new(lua_State *L, int fd, int cap);
+tls_bio_t *tls_bio_new(lua_State *L, int fd, size_t cap);
 
 /**
  * @brief Free the BIO's associated buffers and release the Lua registry

--- a/test/tls/context_test.lua
+++ b/test/tls/context_test.lua
@@ -1340,16 +1340,69 @@ end
 function testcase.connect_bio_bufcap_too_large()
     -- unreasonable bufcap makes BUF_MEM_grow fail; the fix must return
     -- (nil, error) rather than double-free abort.
+    local client = assert(new_tls_client())
+    for _, bufcap in ipairs({
+        2147483000, -- just below INT_MAX
+        2147483648, -- INT_MAX + 1
+        4611686018427387904, -- 2^62
+    }) do
+        local sp = assert(socket.pair({
+            socktype = 'stream',
+        }))
+        -- huge bufcap makes BUF_MEM_grow fail; before the fix this aborted
+        -- with a double free, after the fix connect returns (nil, error).
+        local ctx, err = tls_context.connect(client, sp[1]:fd(), nil, true,
+                                             false, true, true, bufcap)
+        assert.is_nil(ctx)
+        assert(err, 'connect must surface the bio_buf_init failure')
+        sp[1]:close()
+        sp[2]:close()
+    end
+end
+
+function testcase.connect_bio_bufcap_no_int_truncation()
+    -- 2^32 + 1000 used to narrow to int 1000 in tls_bio_new() and silently
+    -- create undersized buffers; the unallocatable request must surface as
+    -- (nil, error) instead.
     local sp = assert(socket.pair({
         socktype = 'stream',
     }))
     local client = assert(new_tls_client())
-    -- huge bufcap makes BUF_MEM_grow fail; before the fix this aborted
-    -- with a double free, after the fix connect returns (nil, error).
     local ctx, err = tls_context.connect(client, sp[1]:fd(), nil, true, false,
-                                         true, true, 2147483000)
+                                         true, true, 4294968296)
     assert.is_nil(ctx)
-    assert(err, 'connect must surface the bio_buf_init failure')
+    assert(err, 'connect must surface the unallocatable bufcap as an error')
+    sp[1]:close()
+    sp[2]:close()
+end
+
+function testcase.accept_bio_bufcap_no_int_truncation()
+    -- accept() shares tls_bio_new() with connect(); the same narrowing
+    -- regression must not silently create undersized buffers there either.
+    local sp = assert(socket.pair({
+        socktype = 'stream',
+    }))
+    local server = assert(new_tls_server(SERVER_CONFIG.cert, SERVER_CONFIG.key))
+    local ctx, err = tls_context.accept(server, sp[1]:fd(), true, 4294968296)
+    assert.is_nil(ctx)
+    assert(err, 'accept must surface the unallocatable bufcap as an error')
+    sp[1]:close()
+    sp[2]:close()
+end
+
+function testcase.connect_bio_bufcap_exact()
+    -- a representable bufcap above the minimum is honoured as-is: the empty
+    -- ring reports exactly the requested writable space.
+    local sp = assert(socket.pair({
+        socktype = 'stream',
+    }))
+    local client = assert(new_tls_client())
+    local cap = 1048576
+    local ctx = assert(tls_context.connect(client, sp[1]:fd(), nil, true, false,
+                                           true, true, cap))
+    local bio = assert(ctx:get_bio())
+    local _, space_len = bio:space()
+    assert.equal(space_len, cap)
     sp[1]:close()
     sp[2]:close()
 end


### PR DESCRIPTION
get_bio_bufcap() returns size_t, but tls_bio_new() / bio_buf_init() took
int, so a bufcap above INT_MAX underwent an implementation-defined
conversion to a negative int that BUF_MEM_grow() re-widened to size_t,
issuing an absurd allocation request. Values at or above 2^32 could also
truncate to a small positive int and silently create undersized buffers.

The capacity path now uses size_t end to end; an unallocatable bufcap
keeps surfacing as (nil, error) from accept() / connect(). The
allocation-failure behaviour is documented in doc/net_tls.md.
