### PR TITLE
Fix TLS BIO close losing the final close_notify

### DIFF
--- a/doc/net_tls.md
+++ b/doc/net_tls.md
@@ -24,3 +24,37 @@ When `context.accept()` / `context.connect()` are called with `use_bio=true`,
 an optional trailing `bufcap` can be supplied. If omitted, or smaller than
 `context.encrypted_length(protocol)`, the minimum safe size is used. A `bufcap`
 that cannot be allocated is reported as an error from these functions.
+
+## Shutdown and close
+
+The graceful TLS shutdown and the resource disposal are separate operations;
+`ctx:shutdown()` performs the former and `ctx:close()` the latter.
+
+### ok, err, want = ctx:shutdown()
+
+Exchanges `close_notify` with the peer. Like the other non-blocking methods,
+it returns `(false, nil, want)` while the transport has to become
+readable/writable again, and `(false, err)` on a fatal error.
+
+**memory BIOs (`use_bio = true`)**
+
+- `true`: the bidirectional shutdown completed. The SSL object is released,
+  but the BIO buffers remain available; the final `close_notify` ciphertext
+  may still be buffered in the TX BIO, so drain it to the socket before
+  `ctx:close()` disposes of the context.
+
+**socket BIOs**
+
+- `true`: our own `close_notify` was handed to the socket; the peer's
+  `close_notify` is not awaited. The SSL object is released.
+
+**nothing to shut down**
+
+- `true` is also returned before the handshake has completed, or on an
+  already shut down / disposed context. Nothing is released in this case;
+  `ctx:close()` disposes of the context.
+
+### ok = ctx:close()
+
+Unconditionally releases the SSL context and the BIO buffers without any
+TLS exchange, and always returns `true`.

--- a/doc/net_tls_socket.md
+++ b/doc/net_tls_socket.md
@@ -21,7 +21,7 @@ the following methods always return an error.
 
 ## About internal IO processing
 
-IO operations (`sock:handshake()`, `sock:tls_close()`, `sock:recv` and `sock:send()`) by tls will return a retry error even if the socket is in blocking mode. if this error occurs, the same function call should be repeated immediately.
+IO operations (`sock:handshake()`, `sock:tls_shutdown()`, `sock:tls_close()`, `sock:recv` and `sock:send()`) by tls will return a retry error even if the socket is in blocking mode. if this error occurs, the same function call should be repeated immediately.
 
 To prevent the possibility of an infinite loop, it is limited by the clock time (default `10 ms`). Use the `sock:setclocklimit()` method to change the time limit if necessary.
 
@@ -81,9 +81,25 @@ it is only necessary to call this method if you need to guarantee that the hands
 - `timeout:boolean`: `true` if operation has timed out.
 
 
+## ok, err, timeout = sock:tls_shutdown()
+
+performs the graceful tls shutdown (`close_notify` exchange; with memory
+BIOs the final `close_notify` ciphertext is drained to the socket). the tls
+context is kept alive; follow up with `sock:tls_close()` to dispose of it.
+
+**Returns**
+
+- `ok:boolean`: `true` on success.
+- `err:error`: error object.
+- `timeout:boolean`: `true` if operation has timed out.
+
+
 ## ok, err, timeout = sock:tls_close()
 
-closes the tls context associated with the socket.
+performs `sock:tls_shutdown()` and then disposes of the tls context
+associated with the socket. the context is disposed even if the graceful
+shutdown fails or times out; the failure is reported through the return
+values.
 
 **Returns**
 

--- a/lib/tls.lua
+++ b/lib/tls.lua
@@ -216,29 +216,28 @@ function Socket:closew()
     return false, new_errno('EOPNOTSUPP')
 end
 
---- tls_close
+--- tls_shutdown
 --- @return boolean ok
 --- @return any err
 --- @return boolean? timeout
-function Socket:tls_close()
-    local tls, close = self.tls, self.tls.close
+function Socket:tls_shutdown()
+    local tls, shutdown = self.tls, self.tls.shutdown
     local deadline = self:get_send_deadline()
 
     while true do
-        local ok, err, want = close(tls)
+        local ok, err, want = shutdown(tls)
         local timeout
 
         if not want then
             if not ok then
-                -- close failed
+                -- shutdown failed
                 return false, err
             end
 
-            -- close succeeded
-            -- if use BIO, drain the newly encrypted record(s) to fd
-            if deadline:is_done() then
-                return false, nil, true
-            end
+            -- shutdown succeeded
+            -- if use BIO, the custom TX BIO may still hold the final
+            -- close_notify ciphertext; drain it to the socket.  draining an
+            -- empty buffer is a no-op.
             ok, err, timeout = bio_drain(self, deadline)
             if not ok then
                 return false, err, timeout
@@ -246,16 +245,25 @@ function Socket:tls_close()
             return true
         end
 
-        if deadline:is_done() then
-            return false, nil, true
-        end
-
         ok, err, timeout = poll_wait(self, want, deadline)
         if not ok then
             return false, err, timeout
         end
-        -- do close again
+        -- do shutdown again
     end
+end
+
+--- tls_close
+--- @return boolean ok
+--- @return any err
+--- @return boolean? timeout
+function Socket:tls_close()
+    local ok, err, timeout = self:tls_shutdown()
+    -- the TLS context is disposed on every exit path; shutdown failure does
+    -- not justify keeping the SSL/BIO objects alive until the GC runs.
+    self.tls_bio = nil
+    self.tls:close()
+    return ok, err, timeout
 end
 
 --- close
@@ -306,15 +314,8 @@ local function handshake(self, deadline)
 
             -- handshake succeeded
             -- if use BIO, drain the newly encrypted record(s) to fd
-            if deadline:is_done() then
-                return false, nil, true
-            end
             self.handshaked, err, timeout = bio_drain(self, deadline)
             return self.handshaked, err, timeout
-        end
-
-        if deadline:is_done() then
-            return false, nil, true
         end
 
         ok, err, timeout = poll_wait(self, want, deadline)

--- a/src/tls_bio.c
+++ b/src/tls_bio.c
@@ -406,8 +406,16 @@ RETRY:
         return 2;
 
     case 0:
-        // closed by peer; mark EOF by returning 0 without an error
-        return 0;
+        // closed by peer.  Bytes already read within this call must not be
+        // discarded: report them as a normal fill so the caller processes
+        // the buffered ciphertext (e.g. a close_notify) before observing
+        // EOF on the next call.
+        if (total == 0) {
+            // mark EOF by returning 0 without an error
+            return 0;
+        }
+        lua_pushinteger(L, (lua_Integer)total);
+        return 1;
 
     default:
         // Successfully read n bytes; commit them to rxbuf and continue.

--- a/src/tls_bio.h
+++ b/src/tls_bio.h
@@ -109,4 +109,17 @@ static inline size_t tls_bio_tx_size(tls_bio_t *bio)
     return zring_data_size(&bio->tx.buf);
 }
 
+/**
+ * @brief Return the number of bytes of ciphertext data currently stored in
+ * the receive buffer, i.e. the amount of data read from the network but not
+ * yet consumed by OpenSSL.
+ *
+ * @param bio BIO containing the receive buffer to query.
+ * @return    Number of bytes of data currently stored in the receive buffer.
+ */
+static inline size_t tls_bio_rx_size(tls_bio_t *bio)
+{
+    return zring_data_size(&bio->rx.buf);
+}
+
 #endif /* net_tls_bio_h */

--- a/src/tls_context.c
+++ b/src/tls_context.c
@@ -331,12 +331,20 @@ static int read_lua(lua_State *L)
     return 1;
 }
 
+/**
+ * @brief Release the SSL object after a completed shutdown.  The BIO buffers
+ * are kept so the caller can drain the final close_notify ciphertext before
+ * disposing of the context with close().
+ */
+static void cleanup_ssl(tls_ctx_t *ctx)
+{
+    SSL_free(ctx->ssl); /* also frees rxbio and txbio */
+    ctx->ssl = NULL;
+}
+
 static void cleanup_context(lua_State *L, tls_ctx_t *ctx)
 {
-    if (ctx->ssl) {
-        SSL_free(ctx->ssl); /* also frees rxbio and txbio */
-        ctx->ssl = NULL;
-    }
+    cleanup_ssl(ctx);
     if (ctx->bio) {
         tls_bio_free(L, ctx->bio);
         ctx->bio = NULL;
@@ -348,14 +356,33 @@ static void cleanup_context(lua_State *L, tls_ctx_t *ctx)
     ctx->handshake_cb = NULL;
 }
 
-static int close_bio_lua(lua_State *L, tls_ctx_t *ctx)
+static int close_lua(lua_State *L)
 {
-    // SSL was fully connected — exchange close_notify with the peer
-    int rv = SSL_shutdown(ctx->ssl);
+    tls_ctx_t *ctx = lauxh_checkudata(L, 1, NET_TLS_CONTEXT_MT);
+
+    // unconditional resource disposal; the graceful TLS shutdown is
+    // performed by shutdown().
+    cleanup_context(L, ctx);
+    lua_pushboolean(L, 1);
+    return 1;
+}
+
+static int shutdown_bio_lua(lua_State *L, tls_ctx_t *ctx)
+{
+    // SSL was fully connected — exchange close_notify with the peer.
+    // On completion only the SSL object is released; the BIO buffers are
+    // kept for the final drain and disposed of by close().
+    size_t rxsize = tls_bio_rx_size(ctx->bio);
+    int rv        = 0;
+
+RETRY:
+    rv = SSL_shutdown(ctx->ssl);
     switch (rv) {
     case 1:
-        // Bidirectional shutdown complete
-        cleanup_context(L, ctx);
+        // Bidirectional shutdown complete.  "Sent" only means OpenSSL wrote
+        // the close_notify into our TX BIO ring, so the caller must still
+        // drain it to the socket before disposing of the context.
+        cleanup_ssl(ctx);
         lua_pushboolean(L, 1);
         return 1;
 
@@ -378,7 +405,19 @@ static int close_bio_lua(lua_State *L, tls_ctx_t *ctx)
         lua_pushinteger(L, rv);
         return 3;
 
-    case SSL_ERROR_WANT_READ:
+    case SSL_ERROR_WANT_READ: {
+        // SSL_MODE_AUTO_RETRY stays disabled (this library is fully
+        // non-blocking), so SSL_shutdown() discards at most one buffered
+        // non-application-data record (e.g. a session ticket) per call.
+        // A WANT_READ with unread ciphertext still in the ring means the
+        // memory BIO is readable right now; per the OpenSSL retry rules we
+        // repeat the call here instead of sending the caller off to poll
+        // the socket for data that is already buffered.
+        size_t rxsize_after = tls_bio_rx_size(ctx->bio);
+        if (rxsize_after != rxsize && rxsize_after > 0) {
+            rxsize = rxsize_after;
+            goto RETRY;
+        }
         // Drain any pending TX before waiting for the peer's close_notify;
         // otherwise we deadlock if our close_notify hasn't been sent yet.
         lua_pushboolean(L, 0);
@@ -386,83 +425,78 @@ static int close_bio_lua(lua_State *L, tls_ctx_t *ctx)
         lua_pushinteger(
             L, tls_bio_tx_size(ctx->bio) > 0 ? SSL_ERROR_WANT_WRITE : rv);
         return 3;
+    }
 
     default:
-        /* Other SSL error: free and report */
-        cleanup_context(L, ctx);
+        /* Other SSL error: report it; the caller disposes via close() */
         lua_pushboolean(L, 0);
-        tls_push_error(L, "close.SSL_shutdown",
+        tls_push_error(L, "shutdown.SSL_shutdown",
                        "failed to shutdown SSL context");
         return 2;
     }
 }
 
-static int close_lua(lua_State *L)
+static int shutdown_lua(lua_State *L)
 {
-    tls_ctx_t *ctx     = lauxh_checkudata(L, 1, NET_TLS_CONTEXT_MT);
-    const char *errop  = NULL;
-    const char *errmsg = NULL;
+    tls_ctx_t *ctx = luaL_checkudata(L, 1, NET_TLS_CONTEXT_MT);
+    int rv         = 0;
 
     if (!ctx->ssl) {
+        // already shut down or disposed
         lua_pushboolean(L, 1);
         return 1;
     } else if (ctx->handshake_cb) {
         // if handshake_cb is not NULL, the handshake is not complete and the
-        // peer won't have any state about this connection, so we can just free
-        // the SSL context without doing SSL_shutdown.
-        cleanup_context(L, ctx);
+        // peer has no state about this connection, so there is nothing to
+        // shut down; the caller disposes of the context with close().
         lua_pushboolean(L, 1);
         return 1;
     }
 
     ERR_clear_error();
     if (ctx->bio) {
-        return close_bio_lua(L, ctx);
+        return shutdown_bio_lua(L, ctx);
     }
 
-    if (!ctx->handshake_cb) {
-        int rv = SSL_shutdown(ctx->ssl);
-        if (rv < 0) {
-            rv = SSL_get_error(ctx->ssl, rv);
-            switch (rv) {
-            case SSL_ERROR_WANT_READ:
-            case SSL_ERROR_WANT_WRITE:
-                lua_pushboolean(L, 0);
-                lua_pushnil(L);
-                lua_pushinteger(L, rv);
-                return 3;
-
-            default:
-                errop  = "close.SSL_shutdown";
-                errmsg = "failed to shutdown SSL context";
-            }
-        }
-    }
-
-    // free ssl context and server reference
-    cleanup_context(L, ctx);
-    lua_pushboolean(L, 1);
-    if (!errop) {
+    rv = SSL_shutdown(ctx->ssl);
+    if (rv >= 0) {
+        // our close_notify was handed to the socket; do not wait for the
+        // peer's close_notify — the caller disposes via close().
+        cleanup_ssl(ctx);
+        lua_pushboolean(L, 1);
         return 1;
     }
-    // error occurred during SSL_shutdown
-    tls_push_error(L, errop, errmsg);
-    return 2;
+
+    rv = SSL_get_error(ctx->ssl, rv);
+    switch (rv) {
+    case SSL_ERROR_WANT_READ:
+    case SSL_ERROR_WANT_WRITE:
+        lua_pushboolean(L, 0);
+        lua_pushnil(L);
+        lua_pushinteger(L, rv);
+        return 3;
+
+    default:
+        lua_pushboolean(L, 0);
+        tls_push_error(L, "shutdown.SSL_shutdown",
+                       "failed to shutdown SSL context");
+        return 2;
+    }
 }
 
 static int get_bio_lua(lua_State *L)
 {
     tls_ctx_t *ctx = lauxh_checkudata(L, 1, NET_TLS_CONTEXT_MT);
 
-    if (!ctx->ssl) {
+    if (ctx->bio) {
+        lauxh_pushref(L, ctx->bio->ref);
+        return 1;
+    } else if (!ctx->ssl) {
+        // the context has been disposed
         lua_pushnil(L);
         lua_errno_new(L, EINVAL, "get_bio");
         return 2;
-    } else if (ctx->bio) {
-        lauxh_pushref(L, ctx->bio->ref);
-        return 1;
     }
-
     return 0;
 }
 
@@ -742,6 +776,7 @@ LUALIB_API int luaopen_net_tls_context(lua_State *L)
         {"read",      read_lua     },
         {"write",     write_lua    },
         {"close",     close_lua    },
+        {"shutdown",  shutdown_lua },
         {"handshake", handshake_lua},
         {NULL,        NULL         }
     };

--- a/test/tls/context_test.lua
+++ b/test/tls/context_test.lua
@@ -673,14 +673,19 @@ local function transfer_read(ep, proc, payload)
     return true
 end
 
---- Close the endpoint, draining any remaining BIO ciphertext.
+--- Close the endpoint: run the graceful TLS shutdown (pumping any
+--- remaining BIO ciphertext, including the final close_notify), then
+--- dispose the context.
 --- @param ep table
 --- @return boolean ok
 --- @return any err
 local function close_ep(ep)
     while true do
-        local ok, err, want = ep.ctx:close()
+        local ok, err, want = ep.ctx:shutdown()
         if ok then
+            -- with BIO, flush the final close_notify ciphertext to the fd
+            pump(ep)
+            assert(ep.ctx:close())
             ep.closed = true
             return true
         elseif want and WANT[want] then
@@ -688,11 +693,11 @@ local function close_ep(ep)
             if not ok2 then
                 return false, ep.name .. ':close:waitio: ' .. tostring(err2)
             end
-        elseif err then
-            return false, ep.name .. ':close: ' .. tostring(err)
         else
+            -- shutdown failed; dispose the context before reporting
+            assert(ep.ctx:close())
             ep.closed = true
-            return true
+            return false, ep.name .. ':close: ' .. tostring(err)
         end
     end
 end
@@ -1403,6 +1408,119 @@ function testcase.connect_bio_bufcap_exact()
     local bio = assert(ctx:get_bio())
     local _, space_len = bio:space()
     assert.equal(space_len, cap)
+    sp[1]:close()
+    sp[2]:close()
+end
+
+--- Drive both endpoints of an in-process BIO pair to a completed handshake
+--- by alternating single handshake steps with pump().
+--- @param cep table client endpoint
+--- @param sep table server endpoint
+--- @return boolean ok
+--- @return any err
+local function handshake_pair(cep, sep)
+    for _ = 1, 100 do
+        if cep.done and sep.done then
+            return true
+        end
+        for _, ep in ipairs({
+            cep,
+            sep,
+        }) do
+            if not ep.done then
+                local ok, err, want = ep.ctx:handshake()
+                pump(ep)
+                if ok then
+                    ep.done = true
+                else
+                    assert(want and WANT[want],
+                           ep.name .. ':handshake: ' .. tostring(err))
+                end
+            end
+        end
+    end
+    return false, 'handshake did not converge'
+end
+
+function testcase.shutdown_close_notify_reaches_peer_bio()
+    -- shutdown() must not free the context; the close_notify ciphertext it
+    -- leaves in the TX BIO has to be drained to the socket so the peer sees
+    -- a clean EOF instead of a truncation.
+    local csock, ssock = make_loopback_pair()
+    local client = assert(new_tls_client())
+    local server = assert(new_tls_server(SERVER_CONFIG.cert, SERVER_CONFIG.key))
+    local cctx = assert(tls_context.connect(client, csock:fd(), nil, true,
+                                            false, true, true))
+    local sctx = assert(tls_context.accept(server, ssock:fd(), true))
+    local cep = new_ep(cctx, 'client', csock:fd())
+    local sep = new_ep(sctx, 'server', ssock:fd())
+    assert(handshake_pair(cep, sep))
+
+    -- the initiator's first shutdown leaves its close_notify in the TX BIO
+    local ok, err, want = cctx:shutdown()
+    assert.is_false(ok)
+    assert.is_nil(err)
+    assert.equal(want, tls_context.WANT_WRITE)
+    -- the context and its BIO must still be alive after the call
+    assert(cctx:get_bio(), 'BIO must survive shutdown()')
+    pump(cep)
+
+    -- retry: close_notify sent, now waiting for the peer's one
+    ok, err, want = cctx:shutdown()
+    assert.is_false(ok)
+    assert.is_nil(err)
+    assert.equal(want, tls_context.WANT_READ)
+
+    -- the peer receives the close_notify as a clean EOF
+    pump(sep)
+    assert.is_nil(sctx:read(1024), 'peer must see close_notify as EOF')
+
+    -- the peer already received our close_notify, so its shutdown completes
+    -- immediately with its own close_notify left in the TX BIO
+    ok, err, want = sctx:shutdown()
+    assert.is_true(ok)
+    assert.is_nil(err)
+    assert.is_nil(want)
+    -- the SSL object is released on completion but the BIO stays available
+    -- for the final drain
+    assert(sctx:get_bio(), 'BIO must survive shutdown() completion')
+    pump(sep)
+    pump(cep)
+
+    -- the initiator's retry completes once the peer's close_notify arrives
+    assert(cctx:shutdown())
+
+    -- close() is a pure disposal and idempotent; shutdown() stays true
+    -- after disposal
+    assert(cctx:close())
+    assert(cctx:close())
+    assert(cctx:shutdown())
+    assert(sctx:close())
+
+    csock:close()
+    ssock:close()
+end
+
+function testcase.shutdown_before_handshake_and_close_idempotent()
+    -- shutdown() before the handshake is a no-op that must not free the
+    -- context; close() is an unconditional disposal and idempotent.
+    local sp = assert(socket.pair({
+        socktype = 'stream',
+    }))
+    local client = assert(new_tls_client())
+    local ctx = assert(tls_context.connect(client, sp[1]:fd(), nil, true, false,
+                                           true, true))
+
+    assert(ctx:shutdown())
+    local bio = assert(ctx:get_bio(), 'BIO must survive shutdown()')
+    -- an empty ring drains as a no-op
+    assert.equal(bio:drain(), 0)
+
+    assert(ctx:close())
+    assert(ctx:close())
+    assert(ctx:shutdown())
+    assert.is_nil(ctx:get_bio())
+
     sp[1]:close()
     sp[2]:close()
 end

--- a/test/tls/stream/inet_test.lua
+++ b/test/tls/stream/inet_test.lua
@@ -837,7 +837,7 @@ function testcase.read_shares_rcvtimeo_with_first_handshake()
         -- longer sndtimeo -- read must honour rcvtimeo.
         local plain = require('net.stream.inet')
         local raw = assert(plain.client.new(host, port))
-        raw:read(nil, 5)  -- keep the connection alive without sending
+        raw:read(nil, 5) -- keep the connection alive without sending
         raw:close()
         return
     end
@@ -853,16 +853,15 @@ function testcase.read_shares_rcvtimeo_with_first_handshake()
     assert.is_nil(msg)
     assert.is_nil(err)
     assert.is_true(timeout, 'read must surface timeout=true')
-    assert(elapsed < 1.5, string.format(
+    assert(elapsed < 1.5,
+           string.format(
                'handshake during read took %.3fs, expected within rcvtimeo' ..
-                   ' (1s) plus jitter; bug allowed up to sndtimeo (5s)',
-               elapsed))
+                   ' (1s) plus jitter; bug allowed up to sndtimeo (5s)', elapsed))
 
     peer:close()
     s:close()
     assert(p:wait())
 end
-
 
 function testcase.write_read_bio_large_payload()
     -- SSL_MODE_ENABLE_PARTIAL_WRITE is enabled on the client SSL_CTX, so a
@@ -921,4 +920,78 @@ function testcase.write_read_bio_large_payload()
     assert(p:wait())
     assert.equal(total, #msg)
     assert.equal(table.concat(buf), msg)
+end
+
+function testcase.close_bio_after_peer_close_notify()
+    -- Regression: once the peer's close_notify has been received,
+    -- SSL_shutdown() completes immediately, but the TX BIO still holds the
+    -- final close_notify ciphertext.  close() must drain it to the socket
+    -- and succeed instead of failing with EINVAL on the freed BIO.
+    local host = '127.0.0.1'
+    local s = assert(inet.server.new(host, 0, {
+        tlscfg = {
+            cert = SERVER_CONFIG.cert,
+            key = SERVER_CONFIG.key,
+            use_bio = true,
+        },
+    }))
+    assert(s:listen())
+    local port = assert(s:getsockname()):port()
+    local msg = 'hello'
+
+    local p = fork()
+    if p:is_child() then
+        s:close()
+        local c = assert(inet.client.new(host, port, {
+            tlscfg = {
+                noverify_name = CLIENT_CONFIG.noverify_name,
+                noverify_time = CLIENT_CONFIG.noverify_time,
+                noverify_cert = CLIENT_CONFIG.noverify_cert,
+                use_bio = true,
+            },
+        }))
+        assert(c:write(msg))
+        -- wait for the server to close first so the peer's close_notify is
+        -- already received when we close
+        local r = c:read()
+        assert.is_nil(r, 'expected EOF before close')
+        assert(c:close(), 'close after peer close_notify must succeed')
+        return
+    end
+    local peer = assert(s:accept())
+    assert.equal(peer:read(), msg)
+    -- the initiator path (SSL_shutdown == 0 -> drain -> retry) must also
+    -- succeed
+    assert(peer:close(), 'initiator close must succeed')
+    s:close()
+    assert(p:wait())
+end
+
+function testcase.close_bio_idempotent()
+    -- close() must be idempotent: the second call disposes nothing extra
+    -- and must not touch the already-freed BIO.
+    local host = '127.0.0.1'
+    local s = assert(inet.server.new(host, 0, {
+        tlscfg = {
+            cert = SERVER_CONFIG.cert,
+            key = SERVER_CONFIG.key,
+            use_bio = true,
+        },
+    }))
+    assert(s:listen())
+    local port = assert(s:getsockname()):port()
+
+    local c = assert(inet.client.new(host, port, {
+        tlscfg = {
+            noverify_name = CLIENT_CONFIG.noverify_name,
+            noverify_time = CLIENT_CONFIG.noverify_time,
+            noverify_cert = CLIENT_CONFIG.noverify_cert,
+            use_bio = true,
+        },
+    }))
+    assert(c.tls_bio ~= nil, 'BIO not set on client')
+    -- closing before the handshake must also succeed and be idempotent
+    assert(c:close())
+    assert(c:close())
+    s:close()
 end


### PR DESCRIPTION
BIO-mode Socket:close() could fail with EINVAL on a healthy connection
once the peer's close_notify had arrived: SSL_shutdown() completed
immediately, close() freed the context, and the wrapper's final BIO
drain hit the freed buffer. The close_notify ciphertext still in the TX
ring could equally be freed before it ever reached the socket.

The graceful shutdown and the disposal are now separate operations:
shutdown() exchanges close_notify, releases only the SSL object on
completion and keeps the BIO buffers for the final drain, while close()
is an unconditional and idempotent disposal. shutdown() also retries
SSL_shutdown() while buffered non-application-data records remain. The
Lua layer gained Socket:tls_shutdown() and tls_close() now disposes the
TLS context on every exit path.

bio:fill() also discarded the bytes read within the same call when the
peer closed right after sending them, so a close_notify that arrived
together with the FIN never reached OpenSSL; it is now reported as a
normal fill and EOF is reported on the next call.
