### PR TITLE
Fix NULL passed to %s when a Lua error is not a string

### DIFF
--- a/src/gcthread.c
+++ b/src/gcthread.c
@@ -200,8 +200,11 @@ void net_gcthread_close(lua_State *L, net_socket_t *s)
 #ifndef NET_GCTHREAD_OUTPUT_STDERR
             // Release build: report to stderr; raising here would allocate new
             // Lua objects and can crash LuaJIT during lua_close finalization.
+            // the error value may be a non-string, in which case
+            // lua_tostring() returns NULL and must not reach fprintf("%s").
+            const char *err = lua_tostring(s->gc_thread, -1);
             fprintf(stderr, "net.socket: gc callback error: %s\n",
-                    lua_tostring(s->gc_thread, -1));
+                    err ? err : "(non-string error value)");
 #endif
             lua_pop(s->gc_thread, 1);
         }

--- a/src/tls_client.c
+++ b/src/tls_client.c
@@ -302,9 +302,12 @@ static void print_error(tls_client_t *c, const char *op, const char *errmsg)
             // succeeded to call error callback
             return;
         }
-        // ouput error of error callback
+        // ouput error of error callback; the error value may be a
+        // non-string, in which case lua_tostring() returns NULL and must
+        // not reach fprintf("%s").
+        const char *err = lua_tostring(c->L, -1);
         fprintf(stderr, "failed to call error callback: %s\n",
-                lua_tostring(c->L, -1));
+                err ? err : "(non-string error value)");
     }
     // output error to stderr
     fprintf(stderr, "%s: %s\n", op, errmsg);

--- a/src/tls_server.c
+++ b/src/tls_server.c
@@ -54,7 +54,11 @@ static int sni_callback(SSL *ssl, int *al, void *arg)
     lauxh_pushref(s->L, s->sni_callback_ref);
     lua_pushstring(s->L, name);
     if (lua_pcall(s->L, 1, 1, 0) != 0) {
-        printf("call closure failed: %s\n", lua_tostring(s->L, -1));
+        // the error value may be a non-string, in which case
+        // lua_tostring() returns NULL and must not reach fprintf("%s").
+        const char *err = lua_tostring(s->L, -1);
+        fprintf(stderr, "call closure failed: %s\n",
+                err ? err : "(non-string error value)");
         // failed to call callback function
         *al = SSL_AD_INTERNAL_ERROR;
         return SSL_TLSEXT_ERR_ALERT_FATAL;

--- a/test/tls/stream/inet_test.lua
+++ b/test/tls/stream/inet_test.lua
@@ -995,3 +995,46 @@ function testcase.close_bio_idempotent()
     assert(c:close())
     s:close()
 end
+
+function testcase.server_sni_callback_raises_non_string_error()
+    -- A Lua error raised through the SNI callback reaches the C callback
+    -- handler as a value of any type; a non-string error must not be
+    -- passed to fprintf("%s") as NULL.  The handshake fails with a fatal
+    -- alert and the server process must survive.
+    local host = '127.0.0.1'
+    local s = assert(inet.server.new(host, 0, {
+        reuseaddr = true,
+        reuseport = true,
+        tlscfg = SERVER_CONFIG,
+    }))
+    assert(s:listen())
+    local port = assert(s:getsockname()):port()
+
+    s:set_sni_callback(function()
+        error({
+            code = 42,
+        })
+    end)
+
+    local p = fork()
+    if p:is_child() then
+        s:close()
+        local c, err = inet.client.new(host, port, {
+            servername = 'www.example.com',
+            tlscfg = CLIENT_CONFIG,
+        })
+        -- the handshake must fail with a fatal alert
+        assert.is_nil(c)
+        assert.match(tostring(err), 'alert|handshake|ssl|certificate', false)
+        return
+    end
+
+    local peer = s:accept()
+    assert(peer, 'server must accept the connection')
+    local msg, rerr = peer:read()
+    assert.is_nil(msg)
+    assert(rerr, 'read must surface the handshake failure')
+    peer:close()
+    s:close()
+    assert(p:wait())
+end


### PR DESCRIPTION
lua_pcall() can leave any value on the stack as the error object;
when it is not a string (e.g. a table thrown by error({})) the
lua_tostring() calls feeding the gc-callback, TLS error-callback
and SNI-callback log messages return NULL, and fprintf("%s", NULL)
is undefined behaviour that only happens to print "(null)" on glibc.

Fall back to a "(non-string error value)" placeholder instead.