### PR TITLE
Fix use-after-free of the BIO userdata after ctx:close()

### DIFF
--- a/src/tls_bio.c
+++ b/src/tls_bio.c
@@ -203,6 +203,12 @@ static int consume_lua(lua_State *L)
     tls_bio_t *bio = luaL_checkudata(L, 1, NET_TLS_BIO_MT);
     lua_Integer n  = lauxh_checkinteger(L, 2);
 
+    if (bio->fd < 0) {
+        // bio has already been freed
+        lua_pushnil(L);
+        lua_errno_new(L, EINVAL, "consume");
+        return 2;
+    }
     if (n < 0 || zring_consume(&bio->tx.buf, (size_t)n) != 0) {
         // format directly with snprintf; lua_pushvfstring rejects %lld on
         // Lua 5.3+ and routing through luaL_error would parse the string
@@ -232,7 +238,15 @@ static int peek_lua(lua_State *L)
 {
     tls_bio_t *bio = luaL_checkudata(L, 1, NET_TLS_BIO_MT);
     size_t len     = 0;
-    void *ptr      = zring_data(&bio->tx.buf, &len);
+    void *ptr      = NULL;
+
+    if (bio->fd < 0) {
+        // bio has already been freed
+        lua_pushnil(L);
+        lua_errno_new(L, EINVAL, "peek");
+        return 2;
+    }
+    ptr = zring_data(&bio->tx.buf, &len);
 
     if (!ptr) {
         lua_pushnil(L);
@@ -319,6 +333,12 @@ static int commit_lua(lua_State *L)
     tls_bio_t *bio = luaL_checkudata(L, 1, NET_TLS_BIO_MT);
     lua_Integer n  = lauxh_checkinteger(L, 2);
 
+    if (bio->fd < 0) {
+        // bio has already been freed
+        lua_pushnil(L);
+        lua_errno_new(L, EINVAL, "commit");
+        return 2;
+    }
     if (n < 0 || zring_commit(&bio->rx.buf, (size_t)n) != 0) {
         // format directly with snprintf; lua_pushvfstring rejects %lld on
         // Lua 5.3+ and routing through luaL_error would parse the string
@@ -348,7 +368,15 @@ static int space_lua(lua_State *L)
 {
     tls_bio_t *bio = luaL_checkudata(L, 1, NET_TLS_BIO_MT);
     size_t len     = 0;
-    void *ptr      = zring_space(&bio->rx.buf, &len);
+    void *ptr      = NULL;
+
+    if (bio->fd < 0) {
+        // bio has already been freed
+        lua_pushnil(L);
+        lua_errno_new(L, EINVAL, "space");
+        return 2;
+    }
+    ptr = zring_space(&bio->rx.buf, &len);
 
     if (!ptr) {
         lua_pushnil(L);
@@ -454,6 +482,10 @@ void tls_bio_free(lua_State *L, tls_bio_t *bio)
         BUF_MEM_free(bio->tx.mem);
         bio->tx.mem = NULL;
     }
+    // reset the ring buffers so the userdata (which Lua code may still
+    // reference) cannot hand out pointers into the freed BUF_MEM.
+    zring_init(&bio->rx.buf, NULL, 0);
+    zring_init(&bio->tx.buf, NULL, 0);
     if (bio->rx_method) {
         BIO_meth_free(bio->rx_method);
         bio->rx_method = NULL;

--- a/test/tls/context_test.lua
+++ b/test/tls/context_test.lua
@@ -2254,3 +2254,44 @@ function testcase.bio_methods_reusable_across_many_connections()
     end
     lsock:close()
 end
+
+function testcase.bio_methods_after_ctx_close()
+    -- get_bio() exposes the BIO userdata to Lua; after ctx:close() freed the
+    -- BUF_MEM backing, space()/peek() used to hand out lightuserdata into
+    -- the freed region (use-after-free).  Every method must report EINVAL
+    -- on the freed BIO instead.
+    local sp = assert(socket.pair({
+        socktype = 'stream',
+    }))
+    local client = assert(new_tls_client())
+    local ctx = assert(tls_context.connect(client, sp[1]:fd(), nil, true, false,
+                                           true, true))
+    local bio = assert(ctx:get_bio())
+
+    assert(ctx:close())
+
+    -- space() / peek() must not return a lightuserdata into freed memory
+    local sptr, slen = bio:space()
+    assert.is_nil(sptr)
+    assert.equal(slen.type, errno.EINVAL)
+    local pptr, plen = bio:peek()
+    assert.is_nil(pptr)
+    assert.equal(plen.type, errno.EINVAL)
+
+    -- commit() / consume() / fill() / drain() must report EINVAL
+    local ok, cerr = bio:commit(0)
+    assert.is_nil(ok)
+    assert.equal(cerr.type, errno.EINVAL)
+    ok, cerr = bio:consume(0)
+    assert.is_nil(ok)
+    assert.equal(cerr.type, errno.EINVAL)
+    local n, ferr = bio:fill()
+    assert.is_nil(n)
+    assert.equal(ferr.type, errno.EINVAL)
+    n, ferr = bio:drain()
+    assert.is_nil(n)
+    assert.equal(ferr.type, errno.EINVAL)
+
+    sp[1]:close()
+    sp[2]:close()
+end


### PR DESCRIPTION
get_bio() exposes the BIO userdata to Lua, so it can outlive the
context that owns it.  tls_bio_free() NULLed the BUF_MEM pointers
and set fd = -1 but left the ring descriptors untouched, and
space()/peek() never checked fd: after ctx:close() they happily
returned lightuserdata into the freed BUF_MEM, and commit()/
consume() advanced positions over the freed region.

tls_bio_free() now resets the ring descriptors and space(), peek(),
commit() and consume() report (nil, EINVAL) on a freed BIO, exactly
like fill() and drain() already did.