### PR TITLE
Fix sendfile EOF and partial-transfer mishandling

### DIFF
--- a/doc/net_stream_socket.md
+++ b/doc/net_stream_socket.md
@@ -125,10 +125,10 @@ send a file from a socket.
 
 - `len:integer`: number of bytes sent.
 - `err:error`: error object.
-- `timeout:boolean`: true if len not equal to bytes or operation has timed out.
+- `timeout:boolean`: true if the operation has timed out before the requested bytes were fully sent.
 
 
-**NOTE:** all return values will be nil if closed by peer.
+**NOTE:** all return values will be nil if closed by peer. If the file holds fewer bytes than requested (or is truncated mid-transfer), the bytes actually sent are returned without a timeout indication.
 
 
 ## len, err, timeout = sock:sendfilesync( fd, bytes [, offset] )

--- a/src/socket.c
+++ b/src/socket.c
@@ -1659,7 +1659,21 @@ static int sendfile_lua(lua_State *L)
     if (nerr) {
         return nerr;
     } else if (sendfile(fd, s->fd, offset, len, NULL, &nbytes, 0) != -1) {
+        if (!nbytes) {
+            // reached to end-of-file: report 0 without "again" so the
+            // caller does not retry on a zero-progress request.
+            lua_pushinteger(L, 0);
+            return 1;
+        }
+        // the BSD sendfile() queues as much as fits into the socket send
+        // buffer and still reports success; a short transfer must be
+        // signalled with "again" so the caller resends the remainder.
         lua_pushinteger(L, nbytes);
+        if (len - (size_t)nbytes) {
+            lua_pushnil(L);
+            lua_pushboolean(L, 1);
+            return 3;
+        }
         return 1;
     } else if (errno == EAGAIN || errno == EINTR) {
         // again

--- a/src/socket.c
+++ b/src/socket.c
@@ -1583,6 +1583,13 @@ static int sendfile_lua(lua_State *L)
     if (nerr) {
         return nerr;
     } else if ((rv = sendfile(s->fd, fd, &offset, len)) != -1) {
+        if (!rv) {
+            // reached to end-of-file: report 0 without "again", otherwise
+            // the caller retries forever with an unchanged offset/length
+            // while the socket stays writable.
+            lua_pushinteger(L, 0);
+            return 1;
+        }
         lua_pushinteger(L, rv);
         if (len - (size_t)rv) {
             lua_pushnil(L);

--- a/test/stream/inet_test.lua
+++ b/test/stream/inet_test.lua
@@ -292,3 +292,33 @@ function testcase.syncwrite_lock_error_returns_nil_len()
     assert.is_nil(len)
     assert.not_nil(error.is(err, errno.ENOTSUP))
 end
+
+function testcase.sendfile_eof()
+    -- Requesting more bytes than the file holds reaches EOF: sendfile must
+    -- report the bytes actually sent and return promptly without driving
+    -- the caller into a zero-progress retry loop until the deadline.
+    -- (Before the Linux fix, rv == 0 was reported as "again" while the
+    -- socket stayed writable, spinning until sndtimeo elapsed.)
+    local _, c, p = open_pair()
+    assert(c:sndtimeo(1))
+    p:close()
+
+    local f = assert(io.open(TESTFILE, 'w'))
+    f:write(string.rep('x', 1024))
+    f:close()
+    local fd = assert(io.open(TESTFILE, 'r'))
+
+    local gettime = require('time.clock').gettime
+    local t0 = gettime()
+    local sent, err, timeout = c:sendfile(fd, 2048, 0)
+    local elapsed = gettime() - t0
+
+    assert.equal(sent, 1024)
+    assert.is_nil(err)
+    assert.is_nil(timeout)
+    -- a busy loop until the deadline would take ~1s (sndtimeo)
+    assert.less(elapsed, 0.9)
+
+    fd:close()
+    c:close()
+end


### PR DESCRIPTION
Linux sendfile() returns 0 at end-of-file, but the success branch
classified it as a short write: with a non-empty request the call
returned (0, nil, again) while neither the offset nor the remaining
length advanced, so Socket:sendfile() retried in a tight loop until
sndtimeo elapsed whenever the socket stayed writable — effectively a
busy loop on a file shorter than the requested byte count (or one
truncated mid-transfer). It now reports the zero as a plain EOF.

The BSD sendfile() queues as much as fits into the socket send
buffer and reports success with the queued count, but the success
branch returned that count without a retry indication, so a request
larger than the buffer was reported as complete with fewer bytes
sent than requested. A short transfer is now signalled with "again"
and a zero count as a plain EOF.

Both match the macOS and fallback variants; a regression test
verifies that requesting more bytes than the file holds returns
promptly with the bytes actually sent.