### PR TITLE
Pass tls_client_t to the OCSP callback via the ctx arg

### DIFF
--- a/src/tls_client.c
+++ b/src/tls_client.c
@@ -316,8 +316,7 @@ static void print_error(tls_client_t *c, const char *op, const char *errmsg)
 // TLS handshake verification callback for stapled requests
 static int ocsp_verify_cb(SSL *ssl, void *arg)
 {
-    (void)arg;
-    tls_client_t *c       = SSL_get_app_data(ssl);
+    tls_client_t *c       = arg;
     ocsp_verify_ctx_t ctx = {0};
     int rc                = verify_ocsp_response(&ctx, ssl);
 
@@ -439,7 +438,8 @@ static int new_lua(lua_State *L)
 
     // set default OCSP callback
     if (SSL_CTX_set_tlsext_status_type(c->ctx, TLSEXT_STATUSTYPE_ocsp) != 1 ||
-        SSL_CTX_set_tlsext_status_cb(c->ctx, ocsp_verify_cb) != 1) {
+        SSL_CTX_set_tlsext_status_cb(c->ctx, ocsp_verify_cb) != 1 ||
+        SSL_CTX_set_tlsext_status_arg(c->ctx, c) != 1) {
         errop  = "SSL_CTX_set_tlsext_status_cb";
         errmsg = "failed to set default OCSP callback";
         goto FAIL;

--- a/src/tls_context.c
+++ b/src/tls_context.c
@@ -683,10 +683,6 @@ static int connect_lua(lua_State *L)
         errop  = "connect.SSL_new";
         errmsg = "failed to create SSL context";
         goto FAIL;
-    } else if (SSL_set_app_data(ctx->ssl, c) != 1) {
-        errop  = "connect.SSL_set_app_data";
-        errmsg = "failed to set app data";
-        goto FAIL;
     }
 
     // The caller asked for hostname verification (noverify_name=0) but did


### PR DESCRIPTION
connect() stored the tls_client_t in the per-connection SSL app_data
so ocsp_verify_cb() could fish it back out with SSL_get_app_data(),
even though the client object owns the SSL_CTX for the whole time
any of its connections can invoke the callback.

Set SSL_CTX_set_tlsext_status_arg() once in new_lua() instead —
the same pattern the SNI callback on the server side already uses —
and drop the per-connection SSL_set_app_data() call along with its
error branch.  The userdata outlives every SSL created from the
context because each connection holds a registry reference to it.