### PR TITLE
Fix TLS callbacks running on a dead lua_State

### DIFF
--- a/src/tls.h
+++ b/src/tls.h
@@ -147,12 +147,11 @@ static inline int tls_check_alpn_table(lua_State *L, int idx)
     return nproto;
 }
 
-typedef int (*tls_handshake_fn)(SSL *);
-
 typedef struct {
     SSL *ssl;
     tls_bio_t *bio;
-    tls_handshake_fn handshake_cb;
+    int (*handshake_cb)(SSL *);
+    void *parent; // tls_server_t* / tls_client_t*; kept alive by parent_ref
     int parent_ref;
 } tls_ctx_t;
 
@@ -229,9 +228,8 @@ static inline int tls_set_cipher_suite(SSL_CTX *ctx, tls_cipher_suite_t suite)
     // does not depend on the OpenSSL defaults. All TLS 1.3 ciphersuites are
     // AEAD with equivalent strength, so every policy shares this list.
     return SSL_CTX_set_ciphersuites(
-        ctx,
-        "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:"
-        "TLS_AES_128_GCM_SHA256");
+        ctx, "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:"
+             "TLS_AES_128_GCM_SHA256");
 #else
     return 1;
 #endif

--- a/src/tls_context.c
+++ b/src/tls_context.c
@@ -47,9 +47,33 @@
 #include <stdio.h>
 #include <sys/types.h>
 
+static int do_handshake(lua_State *L, tls_ctx_t *ctx)
+{
+    int rv = 0;
+
+#define CALL_HANDSHAKE_CB(parent_type)                                         \
+    do {                                                                       \
+        parent_type p     = (parent_type)ctx->parent;                          \
+        lua_State *prev_L = p->L;                                              \
+        p->L              = L;                                                 \
+        rv                = ctx->handshake_cb(ctx->ssl);                       \
+        p->L              = prev_L;                                            \
+    } while (0)
+
+    if (ctx->handshake_cb == SSL_accept) {
+        CALL_HANDSHAKE_CB(tls_server_t *);
+    } else if (ctx->handshake_cb == SSL_connect) {
+        CALL_HANDSHAKE_CB(tls_client_t *);
+    }
+
+#undef CALL_HANDSHAKE_CB
+
+    return rv;
+}
+
 static int handshake_bio_lua(lua_State *L, tls_ctx_t *ctx)
 {
-    int rv = ctx->handshake_cb(ctx->ssl);
+    int rv = do_handshake(L, ctx);
     if (rv == 1) {
         // Handshake is only complete once the last handshake flight has been
         // flushed to the transport.
@@ -107,7 +131,7 @@ static int handshake_lua(lua_State *L)
         return handshake_bio_lua(L, ctx);
     }
 
-    rv = ctx->handshake_cb(ctx->ssl);
+    rv = do_handshake(L, ctx);
     if (rv != 1) {
         rv = SSL_get_error(ctx->ssl, rv);
         switch (rv) {
@@ -353,6 +377,7 @@ static void cleanup_context(lua_State *L, tls_ctx_t *ctx)
         lauxh_unref(L, ctx->parent_ref);
         ctx->parent_ref = LUA_NOREF;
     }
+    ctx->parent       = NULL;
     ctx->handshake_cb = NULL;
 }
 
@@ -595,6 +620,7 @@ static int accept_lua(lua_State *L)
     const char *errmsg = NULL;
 
     ctx->handshake_cb = SSL_accept;
+    ctx->parent       = s;
     ctx->ssl          = SSL_new(s->ctx);
     ctx->bio          = NULL;
     ctx->parent_ref   = LUA_NOREF;
@@ -673,6 +699,7 @@ static int connect_lua(lua_State *L)
     const char *errmsg = NULL;
 
     ctx->handshake_cb = SSL_connect;
+    ctx->parent       = c;
     ctx->ssl          = SSL_new(c->ctx);
     ctx->bio          = NULL;
     ctx->parent_ref   = LUA_NOREF;

--- a/test/tls/context_test.lua
+++ b/test/tls/context_test.lua
@@ -2295,3 +2295,38 @@ function testcase.bio_methods_after_ctx_close()
     sp[1]:close()
     sp[2]:close()
 end
+
+function testcase.connect_handshake_from_coroutine_with_ocsp()
+    -- The OCSP verification callback (and its error reporting) must run on
+    -- the lua_State driving SSL_connect.  Driving the whole handshake from
+    -- a coroutine keeps the creation-time main state suspended while the
+    -- callbacks execute, exercising the handshake_cb -> parent->L refresh.
+    local port = free_port()
+    local proc = start_s_server_with_ocsp(port)
+    local csock = assert(wait_listen(port))
+    local socks = {
+        csock,
+    }
+    local fd = csock:fd()
+
+    local client = assert(new_tls_client())
+    assert(client:load_verify_locations(OCSP_FIXTURE_DIR .. '/ca.crt', '.'))
+    local ctx = assert(tls_context.connect(client, fd, nil, true, false, true,
+                                           false))
+    local ep = new_ep(ctx, 'client', fd)
+
+    local ok, err = coroutine.wrap(function()
+        return handshake(ep)
+    end)()
+    assert(ok, err and tostring(err) or
+               'handshake must complete when driven from a coroutine')
+    ok, err = coroutine.wrap(function()
+        return close_ep(ep)
+    end)()
+    assert(ok, err)
+
+    for _, s in ipairs(socks) do
+        s:close()
+    end
+    proc:close()
+end

--- a/test/tls/stream/inet_test.lua
+++ b/test/tls/stream/inet_test.lua
@@ -1038,3 +1038,49 @@ function testcase.server_sni_callback_raises_non_string_error()
     s:close()
     assert(p:wait())
 end
+
+function testcase.sni_callback_runs_on_handshake_coroutine()
+    -- The SNI callback must execute on the lua_State driving SSL_accept.
+    -- Running the accepted peer's handshake from a coroutine leaves the
+    -- state that created the server object suspended, so a stale
+    -- tls_server_t.L would drive the Lua callback on a suspended state.
+    local host = '127.0.0.1'
+    local s = assert(inet.server.new(host, 0, {
+        reuseaddr = true,
+        reuseport = true,
+        tlscfg = SERVER_CONFIG,
+    }))
+    assert(s:listen())
+    local port = assert(s:getsockname()):port()
+    local msg = 'hello'
+    local ncall = 0
+
+    s:set_sni_callback(function(name)
+        ncall = ncall + 1
+        assert.equal(name, 'www.example.com')
+        return assert(new_tls_server(SERVER_CONFIG.cert, SERVER_CONFIG.key))
+    end)
+
+    local p = fork()
+    if p:is_child() then
+        s:close()
+        local c = assert(inet.client.new(host, port, {
+            servername = 'www.example.com',
+            tlscfg = CLIENT_CONFIG,
+        }))
+        assert(c:send(msg))
+        c:read()
+        c:close()
+        return
+    end
+
+    local peer = assert(s:accept())
+    -- drive the handshake and the data transfer from a coroutine
+    coroutine.wrap(function()
+        assert.equal(peer:recv(), msg)
+    end)()
+    peer:close()
+    s:close()
+    assert(p:wait())
+    assert.equal(ncall, 1)
+end


### PR DESCRIPTION
tls_server_t/tls_client_t capture the lua_State that created the
object, and the SNI and OCSP-verification callbacks invoked by
OpenSSL during SSL_accept/SSL_connect used that captured state.  An
object created inside a coroutine therefore kept pointing at the
coroutine's lua_State; once the coroutine was collected, a later
handshake dereferenced the freed state from the callbacks.

do_handshake() now sets the parent object's lua_State to the one
driving the handshake for the duration of the SSL_accept/SSL_connect
call and restores the previous value afterwards, so every
OpenSSL-invoked Lua callback runs on a state that is guaranteed to
be alive.