### PR TITLE
Guard Lua stack growth in unbounded push loops

### DIFF
--- a/src/gcthread.c
+++ b/src/gcthread.c
@@ -70,6 +70,11 @@ static int gcfn_closure(lua_State *L)
     int has_errfn = !lua_isnil(L, lua_upvalueindex(2));
     int errfunc   = 0;
 
+    // this closure runs on the gc thread via pcall, which guarantees only
+    // LUA_MINSTACK slots; the argument copies can exceed that, so grow the
+    // stack explicitly.  The raised error is caught by the pcall in
+    // net_gcthread_close().
+    luaL_checkstack(L, nargs + 2, "too many gc callback arguments");
     if (has_errfn) {
         lua_pushvalue(L, lua_upvalueindex(2));
         errfunc = lua_gettop(L);
@@ -115,6 +120,14 @@ int net_gcthread_add(lua_State *L, net_socket_t *s, int argidx)
     // Push upvalues onto the socket's gc thread stack in the order the
     // closure expects:
     //   [1] nargs, [2] errfn (or nil), [3] fn, [4..3+nargs] extra args
+    // The gc thread is not the running state, so its stack must be grown
+    // explicitly; luaL_checkstack() would try to raise the error on the
+    // non-running state and panic.  Raise the Lua error on the caller's
+    // (running) state instead, like every other allocation failure in the
+    // library.
+    if (!lua_checkstack(s->gc_thread, nargs + 4)) {
+        return luaL_error(L, "too many arguments to addgcfn");
+    }
     lua_pushinteger(s->gc_thread, nargs);
     if (lua_isnoneornil(L, argidx)) {
         lua_pushnil(s->gc_thread);
@@ -169,14 +182,11 @@ int net_gcthread_del(lua_State *L, net_socket_t *s, int handle_idx)
 
     for (int i = 1, top = lua_gettop(s->gc_thread); i <= top; i++) {
         if (lua_topointer(s->gc_thread, i) == ptr) {
-            // Remove element at index i by shifting upper elements down.
-            // Lua 5.1 compatible: no lua_copy; use lua_pushvalue +
-            // lua_replace pairs and finally trim with lua_settop.
-            for (int j = i; j < top; j++) {
-                lua_pushvalue(s->gc_thread, j + 1);
-                lua_replace(s->gc_thread, j);
-            }
-            lua_settop(s->gc_thread, top - 1);
+            // Remove the closure in place.  lua_remove() shifts the upper
+            // elements down within the existing stack, so unlike the
+            // pushvalue+replace dance it never needs a spare slot above
+            // the stack high-water mark.
+            lua_remove(s->gc_thread, i);
             lua_pushboolean(L, 1);
             return 1;
         }

--- a/src/tls.h
+++ b/src/tls.h
@@ -28,6 +28,7 @@
 #include "lauxhlib.h"
 #include "lua_error.h"
 // lua
+#include <lauxlib.h>
 #include <lua.h>
 // system
 #include <openssl/err.h>
@@ -358,6 +359,11 @@ static inline void tls_push_error(lua_State *L, const char *default_errop,
 
     // push error messages in reverse order
     while (err) {
+        // the queue length is unbounded; keep the running state's stack
+        // in check so a deep error queue raises a Lua error instead of
+        // overflowing the stack.  ERR_error_string(err, NULL) renders the
+        // pending error without consuming it from the queue.
+        luaL_checkstack(L, 3, ERR_error_string(err, NULL));
         lua_pushstring(L, errop);
         lua_pushstring(L, ERR_error_string(ERR_get_error(), NULL));
         msgidx++;
@@ -374,6 +380,9 @@ static inline void tls_push_error(lua_State *L, const char *default_errop,
     while (err) {
         const char *errop  = ERR_func_error_string(err);
         const char *errmsg = ERR_error_string(err, NULL);
+        // keep the running state's stack in check; reuse the pending error
+        // text (already dequeued above) as the overflow message.
+        luaL_checkstack(L, 3, errmsg);
         lua_pushstring(L, errmsg);
         lua_pushstring(L, errop);
         lua_error_new_message(L, ++msgidx);

--- a/test/socket_test.lua
+++ b/test/socket_test.lua
@@ -8,6 +8,9 @@ local errno = require('errno')
 local addrinfo = require('net.addrinfo')
 local socket = require('net.socket')
 
+-- unpack() moved to table.unpack in Lua 5.2
+local unpack = unpack or table.unpack
+
 -- SCM_CREDENTIALS is a Linux-only cmsg type.  On other platforms (macOS,
 -- most BSDs) the equivalent SCM_CREDS has no reliable explicit-send API
 -- that we can exercise from Lua, so we skip the test there.
@@ -5990,17 +5993,18 @@ function testcase.addgcfn_too_many_arguments()
     for i = 1, 200 do
         args[i] = i
     end
-    local err
-    for _ = 1, 50000 do
-        local ok
-        ok, err = pcall(s.addgcfn, s, nil, function() end, unpack(args))
+    -- the number of registrations before the guard fires depends on the
+    -- runtime's stack limit (~7.7k on Lua 5.1, ~1M on Lua 5.2+), so keep
+    -- registering until the guard fires instead of assuming a threshold.
+    local fired = false
+    for _ = 1, 1000000 do
+        local ok = pcall(s.addgcfn, s, nil, function() end, unpack(args))
         if not ok then
-            assert.match(tostring(err), 'too many arguments to addgcfn')
-            err = nil -- expected guard; not a failure
+            fired = true
             break
         end
     end
-    assert.is_nil(err, 'guard must fire within 50000 registrations')
+    assert.is_true(fired, 'guard must fire before the registration loop ends')
 
     assert(s:close())
 end

--- a/test/socket_test.lua
+++ b/test/socket_test.lua
@@ -5972,3 +5972,62 @@ function testcase.recv_family_rejects_msg_trunc_input_flag()
     a:close()
     b:close()
 end
+
+function testcase.addgcfn_too_many_arguments()
+    -- Pushing the gc callback's extra arguments onto the socket's gc
+    -- thread must go through the stack guard: an argument count the
+    -- thread stack cannot hold raises a Lua error instead of writing
+    -- past the end of the thread stack (SIGSEGV/SIGBUS before the fix).
+    -- A single large call is legitimately accepted when the stack can
+    -- grow that far, so keep registering 200-argument callbacks until
+    -- the guard fires.
+    local s = assert(socket.new_inet({
+        socktype = 'stream',
+        protocol = 'tcp',
+    }))
+
+    local args = {}
+    for i = 1, 200 do
+        args[i] = i
+    end
+    local err
+    for _ = 1, 50000 do
+        local ok
+        ok, err = pcall(s.addgcfn, s, nil, function() end, unpack(args))
+        if not ok then
+            assert.match(tostring(err), 'too many arguments to addgcfn')
+            err = nil -- expected guard; not a failure
+            break
+        end
+    end
+    assert.is_nil(err, 'guard must fire within 50000 registrations')
+
+    assert(s:close())
+end
+
+function testcase.addgcfn_repeated_registration_hits_guard()
+    -- Even with few arguments per call, repeated registrations keep
+    -- growing the gc thread stack; the guard must eventually raise a
+    -- Lua error (or keep accepting after legitimately growing the stack)
+    -- instead of corrupting the heap.
+    local s = assert(socket.new_inet({
+        socktype = 'stream',
+        protocol = 'tcp',
+    }))
+
+    local ok = true
+    local err
+    for _ = 1, 10000 do
+        ok, err = pcall(s.addgcfn, s, nil, function() end)
+        if not ok then
+            break
+        end
+    end
+    -- either every registration succeeded (stack grew legitimately) or a
+    -- guard error surfaced; both are acceptable, a crash is not.
+    if not ok then
+        assert.match(tostring(err), 'too many arguments to addgcfn')
+    end
+
+    assert(s:close())
+end


### PR DESCRIPTION
addgcfn() grew the gc-thread stack without any check; the thread
keeps its initial 40-slot allocation, so writing past it corrupts
the heap and eventually crashes (SIGSEGV/SIGBUS, or a PANIC abort
on LuaJIT).  gcfn_closure()'s argument copies and tls_push_error()'s
error-queue drain had the same flaw on their running states.

addgcfn() now grows the thread stack up front and raises a Lua error
on the caller's state on failure; the other two use luaL_checkstack()
and delgcfn() removes its closure with the in-place lua_remove().