### PR TITLE
Unify the send APIs on a len-always-numeric contract

### DIFF
--- a/doc/net_dgram_socket.md
+++ b/doc/net_dgram_socket.md
@@ -189,11 +189,9 @@ send a message to specified destination address.
 
 **Returns**
 
-- `len:integer`: the number of bytes sent.
+- `len:integer`: the number of bytes sent. Always a number: check `err` for the outcome; `len` reports how many bytes were accepted before a failure (`0` when none were).
 - `err:error`: error object.
-- `timeout:boolean`: true if len not equal to #str or operation has timed out.
-
-**NOTE:** all return values will be nil if closed by peer.
+- `timeout:boolean`: `true` if operation has timed out; `len` still reports the bytes accepted so far.
 
 
 ## len, err, timeout = sock:sendtosync( str, ai )

--- a/doc/net_socket.md
+++ b/doc/net_socket.md
@@ -467,11 +467,9 @@ write a message to a socket.
 
 **Returns**
 
-- `len:integer`: the number of bytes written.
+- `len:integer`: the number of bytes written. Always a number: check `err` for the outcome; `len` reports how many bytes were accepted before a failure (`0` when none were).
 - `err:error`: error object.
-- `timeout:boolean`: `true` if len is not equal to `#str` or operation has timed out.
-
-**NOTE:** all return values will be nil if closed by peer.
+- `timeout:boolean`: `true` if operation has timed out; `len` still reports the bytes accepted so far.
 
 **NOTE:** every write path (`write`, `send`, `sendmsg`, `sendfd`,
 `sendfile` and the TLS drain) suppresses `SIGPIPE` in-process; a write to
@@ -496,11 +494,9 @@ send a message to a socket.
 
 **Returns**
 
-- `len:integer`: the number of bytes sent.
+- `len:integer`: the number of bytes sent. Always a number: check `err` for the outcome; `len` reports how many bytes were accepted before a failure (`0` when none were).
 - `err:error`: error object.
-- `timeout:boolean`: `true` if len is not equal to `#str` or operation has timed out.
-
-**NOTE:** all return values will be nil if closed by peer.
+- `timeout:boolean`: `true` if operation has timed out; `len` still reports the bytes accepted so far.
 
 
 ## len, err, timeout = sock:sendsync( str [, flag, ...] )
@@ -525,10 +521,9 @@ send a message and optional ancillary data (cmsgs) via a socket.
 
 **Returns**
 
-- `len:integer`: the number of payload bytes sent.
+- `len:integer`: the number of payload bytes sent. Always a number: check `err` for the outcome; `len` reports how many bytes were accepted before a failure (`0` when none were).
 - `err:error`: error object.
-- `timeout:boolean`: `true` when the deadline elapsed with bytes still
-  to send.
+- `timeout:boolean`: `true` when the deadline elapsed with bytes still to send; `len` still reports the bytes accepted so far.
 
 **NOTE:** at least one of `msg` and `cmsg` must be provided.
 

--- a/doc/net_stream_socket.md
+++ b/doc/net_stream_socket.md
@@ -123,12 +123,12 @@ send a file from a socket.
 
 **Returns**
 
-- `len:integer`: number of bytes sent.
+- `len:integer`: number of bytes sent. Always a number: check `err` for the outcome; `len` reports how many bytes were accepted before a failure (`0` when none were).
 - `err:error`: error object.
-- `timeout:boolean`: true if the operation has timed out before the requested bytes were fully sent.
+- `timeout:boolean`: true if the operation has timed out before the requested bytes were fully sent; `len` still reports the bytes accepted so far.
 
 
-**NOTE:** all return values will be nil if closed by peer. If the file holds fewer bytes than requested (or is truncated mid-transfer), the bytes actually sent are returned without a timeout indication.
+**NOTE:** If the file holds fewer bytes than requested (or is truncated mid-transfer), the bytes actually sent are returned without a timeout indication.
 
 
 ## len, err, timeout = sock:sendfilesync( fd, bytes [, offset] )

--- a/doc/net_tls_socket.md
+++ b/doc/net_tls_socket.md
@@ -140,11 +140,9 @@ write a message to a socket.
 
 **Returns**
 
-- `len:integer`: the number of bytes written.
+- `len:integer`: the number of bytes written. Always a number: check `err` for the outcome; `len` reports how many bytes were accepted before a failure (`0` when none were).
 - `err:error`: error object.
-- `timeout:boolean`: `true` if len is not equal to `#str` or operation has timed out.
-
-**NOTE:** all return values will be nil if closed by peer.
+- `timeout:boolean`: `true` if operation has timed out; `len` still reports the bytes accepted so far.
 
 
 ## len, err, timeout = sock:send( str )

--- a/doc/net_unix_socket.md
+++ b/doc/net_unix_socket.md
@@ -16,11 +16,9 @@ send file descriptors along unix domain sockets.
 
 **Returns**
 
-- `len:integer`: the number of bytes sent (always zero).
+- `len:integer`: the number of bytes sent (always zero). Always a number: check `err` for the outcome.
 - `err:error`: error object.
 - `timeout:boolean`: `true` if errno is `EAGAIN`, `EWOULDBLOCK`, `EINTR`.
-
-**NOTE:** all return values will be nil if closed by peer.
 
 
 ## len, err, timeout = sock:sendfdsync( fd [, ai [, flag, ...]] )

--- a/lib/dgram.lua
+++ b/lib/dgram.lua
@@ -172,7 +172,7 @@ function Socket:sendto(str, ai, ...)
         local len, err, again = sendto(sock, str, ai, ...)
 
         if not len then
-            return nil, err
+            return sent, err
         end
         -- update a bytes sent
         sent = len + sent

--- a/lib/stream.lua
+++ b/lib/stream.lua
@@ -109,7 +109,7 @@ function Socket:sendfile(fd, bytes, offset)
         local len, err, again = sendfile(sock, fd, bytes, offset)
 
         if not len then
-            return nil, err
+            return sent, err
         end
         -- update a bytes sent
         sent = sent + len

--- a/lib/tls.lua
+++ b/lib/tls.lua
@@ -451,7 +451,7 @@ function Socket:write(str)
 
         local len, err, want = write(sock, str)
         if not len then
-            return nil, err
+            return sent, err
         end
         -- update a bytes sent
         sent = sent + len
@@ -462,7 +462,7 @@ function Socket:write(str)
             -- if use BIO, drain the newly encrypted record(s) to fd
             ok, err, timeout = bio_drain(self, deadline)
             if not ok then
-                return nil, err, timeout
+                return sent, err, timeout
             end
             return sent
         end

--- a/lib/tls/stream.lua
+++ b/lib/tls/stream.lua
@@ -120,10 +120,8 @@ function Socket:sendfile(f, bytes, offset)
 
         -- send a content
         local len, serr, timeout = self:send(data)
-        if len then
-            -- update a bytes sent
-            sent = sent + len
-        end
+        -- Go style: send always reports a numeric sent count.
+        sent = sent + len
 
         if serr then
             return sent, serr

--- a/lib/unix.lua
+++ b/lib/unix.lua
@@ -41,7 +41,7 @@ function Socket:sendfd(fd, ai, ...)
         local len, err, again = sendfd(sock, fd, ai, ...)
 
         if not len then
-            return nil, err
+            return 0, err
         elseif not again then
             return len
         end

--- a/net.lua
+++ b/net.lua
@@ -615,7 +615,7 @@ function Socket:write(str)
         local len, err, again = write(sock, str)
 
         if not len then
-            return nil, err
+            return sent, err
         end
         -- update a bytes sent
         sent = sent + len
@@ -663,7 +663,7 @@ function Socket:send(str, ...)
         local len, err, again = send(sock, str, ...)
 
         if not len then
-            return nil, err
+            return sent, err
         end
         -- update a bytes sent
         sent = sent + len
@@ -714,16 +714,17 @@ function Socket:sendmsg(msg, addr, cmsg, ...)
         local len, err, again = sendmsg(sock, msg, addr, cmsg, ...)
 
         if not len then
-            return nil, err
-        elseif len > 0 then
-            -- update a bytes sent
-            sent = sent + len
-            if msg then
-                msg = msg:sub(len + 1)
-            end
-            -- cmsg is only sent once with the first fragment
-            cmsg = nil
+            return sent, err
         end
+        -- update a bytes sent
+        sent = sent + len
+
+        if msg then
+            -- remove the sent part from the message
+            msg = msg:sub(len + 1)
+        end
+        -- cmsg is only sent once with the first fragment
+        cmsg = nil
 
         if not again then
             return sent

--- a/test/stream/inet_test.lua
+++ b/test/stream/inet_test.lua
@@ -137,6 +137,36 @@ function testcase.write_read()
     assert.equal(assert(peer:read()), 'hello')
 end
 
+function testcase.write_error_returns_zero_len()
+    -- Go-style contract: a failed write() must return (0, err) rather
+    -- than (nil, err) so callers always have the sent count.
+    local s = assert(inet.server.new('127.0.0.1', 0, {
+        reuseaddr = true,
+        reuseport = true,
+    }))
+    assert(s:listen())
+    local port = assert(s:getsockname()):port()
+    local c = assert(inet.client.new('127.0.0.1', port))
+    local peer = assert(s:accept())
+
+    peer:close()
+
+    -- after the peer closed, writes eventually surface EPIPE; the first
+    -- may still succeed into the kernel buffer, so loop.
+    local sent, err
+    for _ = 1, 8 do
+        sent, err = c:write(string.rep('x', 1024))
+        if err then
+            break
+        end
+    end
+    assert(err, 'write should surface an error after peer close')
+    assert.equal(sent, 0, 'failed write must report len 0, not nil')
+
+    c:close()
+    s:close()
+end
+
 function testcase.send_recv()
     local _, c, peer = open_pair()
     -- send from client, recv on the accepted peer.
@@ -322,3 +352,4 @@ function testcase.sendfile_eof()
     fd:close()
     c:close()
 end
+

--- a/test/tls/stream/inet_test.lua
+++ b/test/tls/stream/inet_test.lua
@@ -1207,7 +1207,8 @@ function testcase.write_drain_error_keeps_sent()
             -- nothing had been accepted yet, never nil).
             assert.is_number(sent, 'sent must stay a number on failure')
             assert(sent >= 0)
-            assert.match(tostring(err), 'EPIPE')
+            assert(err.type == errno.EPIPE or err.type == errno.ECONNRESET,
+                   'unexpected drain error: ' .. tostring(err))
             failed = true
             break
         end

--- a/test/tls/stream/inet_test.lua
+++ b/test/tls/stream/inet_test.lua
@@ -1147,3 +1147,74 @@ function testcase.read_returns_data_with_pending_txbuf()
     s:close()
     assert(p:wait())
 end
+
+function testcase.write_drain_error_keeps_sent()
+    -- Go-style contract: when the TX BIO drain fails after OpenSSL
+    -- accepted the plaintext, write() must report the accepted byte
+    -- count with (sent, err) instead of discarding it with nil —
+    -- re-sending accepted plaintext would duplicate it on the wire.
+    local host = '127.0.0.1'
+    local s = assert(inet.server.new(host, 0, {
+        reuseaddr = true,
+        reuseport = true,
+        sndbuf = 2048,
+        rcvbuf = 2048,
+        tlscfg = {
+            cert = SERVER_CONFIG.cert,
+            key = SERVER_CONFIG.key,
+            use_bio = true,
+        },
+    }))
+    assert(s:listen())
+    local port = assert(s:getsockname()):port()
+    local big = string.rep('hello-', 4000)
+
+    local p = fork()
+    if p:is_child() then
+        s:close()
+        local c = assert(inet.client.new(host, port, {
+            sndbuf = 2048,
+            rcvbuf = 2048,
+            tlscfg = {
+                noverify_name = CLIENT_CONFIG.noverify_name,
+                noverify_time = CLIENT_CONFIG.noverify_time,
+                noverify_cert = CLIENT_CONFIG.noverify_cert,
+                use_bio = true,
+            },
+        }))
+        -- complete the handshake, then close the connection so the
+        -- server's later drains hit EPIPE
+        assert(c:write('ping'))
+        c:read()
+        require('time.sleep')(1)
+        c:close()
+        return
+    end
+
+    local peer = assert(s:accept())
+    assert(peer.tls_bio ~= nil, 'BIO not set on peer')
+    assert.equal(peer:read(), 'ping')
+    assert(peer:sndtimeo(5))
+
+    -- keep writing until the drain fails; the accepted plaintext count
+    -- must survive the failure.
+    local failed = false
+    for _ = 1, 300 do
+        local sent, err, timeout = peer:write(big)
+        if err then
+            assert.is_nil(timeout)
+            -- Go style: the sent count must survive the failure (0 when
+            -- nothing had been accepted yet, never nil).
+            assert.is_number(sent, 'sent must stay a number on failure')
+            assert(sent >= 0)
+            assert.match(tostring(err), 'EPIPE')
+            failed = true
+            break
+        end
+    end
+    assert.is_true(failed, 'drain must fail within 300 writes')
+
+    peer:close()
+    s:close()
+    assert(p:wait())
+end


### PR DESCRIPTION
len is now always a number reporting the bytes accepted so far (0
when none were) and the outcome is signalled by err alone, uniformly
across write, send, sendmsg, sendfd, sendfile, sendto and the TLS
write.  Callers no longer need to inspect both values, and the TLS
write no longer drops the count OpenSSL already accepted when its
BIO drain fails, which invited a duplicate re-send of the plaintext.