### PR TITLE
Reject out-of-range fds before narrowing lua_Integer to int

### DIFF
--- a/src/cmsghdr.c
+++ b/src/cmsghdr.c
@@ -73,8 +73,10 @@ static void push_cmsg_block(lua_State *L, int level, int type,
 #define NET_CMSG_MAX_FD 256
 
 // Read the SCM_RIGHTS payload at Lua stack index `dataidx` (an integer fd or
-// an integer[] table of fds) and push a serialized cmsg block onto L.  Raises
-// via luaL_error on malformed data.
+// an integer[] table of fds) and push a serialized cmsg block onto L.  Every
+// fd must be an integral value in 0..INT_MAX; narrowing an out-of-range
+// lua_Integer to int would wrap onto an unrelated descriptor number inside
+// the SCM_RIGHTS payload.  Raises via luaL_error on malformed data.
 static void push_scm_rights_entry(lua_State *L, int i, int level, int type,
                                   int dataidx)
 {
@@ -82,10 +84,20 @@ static void push_scm_rights_entry(lua_State *L, int i, int level, int type,
     size_t nfd = 0;
 
     switch (lua_type(L, dataidx)) {
-    case LUA_TNUMBER:
-        fds[0] = (int)lua_tointeger(L, dataidx);
+    case LUA_TNUMBER: {
+        lua_Integer fd = 0;
+        if (!lauxh_isinteger(L, dataidx)) {
+            luaL_error(L, "cmsg[%d].data must be integer fd", i);
+        }
+        fd = lua_tointeger(L, dataidx);
+        if (fd < 0 || fd > INT_MAX) {
+            luaL_error(L, "cmsg[%d].data: fd must be in the range 0..%d", i,
+                       INT_MAX);
+        }
+        fds[0] = (int)fd;
         nfd    = 1;
         break;
+    }
 
     case LUA_TTABLE: {
         lua_Integer tlen = (lua_Integer)lauxh_rawlen(L, dataidx);
@@ -94,12 +106,19 @@ static void push_scm_rights_entry(lua_State *L, int i, int level, int type,
                        (int)NET_CMSG_MAX_FD);
         }
         for (lua_Integer j = 1; j <= tlen; j++) {
+            lua_Integer fd = 0;
             lua_rawgeti(L, dataidx, (int)j);
-            if (lua_type(L, -1) != LUA_TNUMBER) {
+            if (!lauxh_isinteger(L, -1)) {
                 luaL_error(L, "cmsg[%d].data[%d] must be integer fd", i,
                            (int)j);
             }
-            fds[j - 1] = (int)lua_tointeger(L, -1);
+            fd = lua_tointeger(L, -1);
+            if (fd < 0 || fd > INT_MAX) {
+                luaL_error(L,
+                           "cmsg[%d].data[%d]: fd must be in the range 0..%d",
+                           i, (int)j, INT_MAX);
+            }
+            fds[j - 1] = (int)fd;
             lua_pop(L, 1);
         }
         nfd = (size_t)tlen;

--- a/src/socket.c
+++ b/src/socket.c
@@ -1397,9 +1397,10 @@ static int sendto_lua(lua_State *L)
 static int sendfd_lua(lua_State *L)
 {
     net_socket_t *s        = lauxh_checkudata(L, 1, SOCKET_MT);
-    lua_Integer fd         = lauxh_checkinteger(L, 2);
+    lua_Integer fdarg      = lauxh_checkinteger(L, 2);
     net_addrinfo_t *info   = lauxh_optudata(L, 3, NET_ADDRINFO_MT, NULL);
     int flg                = net_check_msgflags(L, 4);
+    int fd                 = 0;
     // NOTE: on linux, auxiliary data must be sent along with at least 1 byte of
     // real data in order to be sent.
     char iov_data          = 1;
@@ -1421,12 +1422,23 @@ static int sendfd_lua(lua_State *L)
         .msg_iov        = &empty_iov,
         .msg_iovlen     = 1,
         .msg_control    = &ctrl.data,
-        .msg_controllen = ctrl.data.cmsg_len,
+        .msg_controllen = sizeof(ctrl.buf),
         .msg_flags      = 0,
     };
 
-    // set fd
-    *(int *)CMSG_DATA(&ctrl.data) = fd;
+    // narrowing an out-of-range lua_Integer to int would wrap onto an
+    // unrelated descriptor number inside the SCM_RIGHTS payload
+    if (fdarg < 0 || fdarg > INT_MAX) {
+        lua_pushnil(L);
+        errno = EINVAL;
+        lua_errno_new(L, errno, "sendfd_lua");
+        return 2;
+    }
+    fd = (int)fdarg;
+
+    // set fd; CMSG_DATA() alignment is only guaranteed for the cmsghdr
+    // itself, so the payload is copied byte-wise via memcpy
+    memcpy(CMSG_DATA(&ctrl.data), &fd, sizeof(fd));
 
     // set msg_name
     if (info) {
@@ -1536,31 +1548,36 @@ static int sendmsg_lua(lua_State *L)
     return 3;
 }
 
-static inline int checkfile(lua_State *L, int idx)
-{
-    if (lauxh_isinteger(L, idx)) {
-        return lua_tointeger(L, idx);
-    }
-    return fileno(lauxh_checkfile(L, idx));
-}
-
-// Validate the size (index 3) and offset (index 4) arguments common to every
-// sendfile_lua variant.  Casting a negative lua_Integer straight to size_t
+// Validate the fd (index 2), size (index 3) and offset (index 4) arguments
+// common to every sendfile_lua variant.  Index 2 accepts an integer fd or a
+// FILE*; the integer form is range-checked before the cast to int because
+// narrowing an out-of-range lua_Integer would wrap onto an unrelated
+// descriptor number.  Casting a negative lua_Integer straight to size_t
 // turns -1 into SIZE_MAX, so the checks live on the signed source values
-// before the cast.  On success writes size/offset to *out_len / *out_off and
-// returns 0.  On failure pushes (nil, EINVAL error) and returns the Lua-side
-// return count so the caller can propagate it verbatim.
-static int check_sendfile_args(lua_State *L, size_t *out_len, off_t *out_off)
+// before the cast.  On success writes fd/size/offset to *out_fd / *out_len /
+// *out_off and returns 0.  On failure pushes (nil, EINVAL error) and returns
+// the Lua-side return count so the caller can propagate it verbatim.
+static int check_sendfile_args(lua_State *L, int *out_fd, size_t *out_len,
+                               off_t *out_off)
 {
+    lua_Integer fd   = 0;
     lua_Integer size = lauxh_checkinteger(L, 3);
     lua_Integer off  = lauxh_optinteger(L, 4, 0);
 
-    if (size <= 0 || (uintmax_t)size > SIZE_MAX || off < 0) {
+    if (lauxh_isinteger(L, 2)) {
+        fd = lua_tointeger(L, 2);
+    } else {
+        fd = fileno(lauxh_checkfile(L, 2));
+    }
+
+    if (fd < 0 || fd > INT_MAX || size <= 0 || (uintmax_t)size > SIZE_MAX ||
+        off < 0) {
         lua_pushnil(L);
         errno = EINVAL;
         lua_errno_new(L, errno, "sendfile_lua");
         return 2;
     }
+    *out_fd  = (int)fd;
     *out_len = (size_t)size;
     *out_off = (off_t)off;
     return 0;
@@ -1574,11 +1591,11 @@ static int check_sendfile_args(lua_State *L, size_t *out_len, off_t *out_off)
 static int sendfile_lua(lua_State *L)
 {
     net_socket_t *s = lauxh_checkudata(L, 1, SOCKET_MT);
-    int fd          = checkfile(L, 2);
+    int fd          = 0;
     size_t len      = 0;
     off_t offset    = 0;
     ssize_t rv      = 0;
-    int nerr        = check_sendfile_args(L, &len, &offset);
+    int nerr        = check_sendfile_args(L, &fd, &len, &offset);
 
     if (nerr) {
         return nerr;
@@ -1617,10 +1634,10 @@ static int sendfile_lua(lua_State *L)
 static int sendfile_lua(lua_State *L)
 {
     net_socket_t *s = lauxh_checkudata(L, 1, SOCKET_MT);
-    int fd          = checkfile(L, 2);
+    int fd          = 0;
     size_t size     = 0;
     off_t offset    = 0;
-    int nerr        = check_sendfile_args(L, &size, &offset);
+    int nerr        = check_sendfile_args(L, &fd, &size, &offset);
 
     if (nerr) {
         return nerr;
@@ -1650,11 +1667,11 @@ static int sendfile_lua(lua_State *L)
 static int sendfile_lua(lua_State *L)
 {
     net_socket_t *s = lauxh_checkudata(L, 1, SOCKET_MT);
-    int fd          = checkfile(L, 2);
+    int fd          = 0;
     size_t len      = 0;
     off_t offset    = 0;
     off_t nbytes    = 0;
-    int nerr        = check_sendfile_args(L, &len, &offset);
+    int nerr        = check_sendfile_args(L, &fd, &len, &offset);
 
     if (nerr) {
         return nerr;
@@ -1704,12 +1721,12 @@ static int sendfile_lua(lua_State *L)
 static int sendfile_lua(lua_State *L)
 {
     net_socket_t *s = lauxh_checkudata(L, 1, SOCKET_MT);
-    int fd          = checkfile(L, 2);
+    int fd          = 0;
     size_t len      = 0;
     off_t offset    = 0;
     ssize_t nbytes  = 0;
     void *buf       = NULL;
-    int nerr        = check_sendfile_args(L, &len, &offset);
+    int nerr        = check_sendfile_args(L, &fd, &len, &offset);
 
     if (nerr) {
         return nerr;
@@ -1901,7 +1918,7 @@ static int recvfd_lua(lua_State *L)
         .msg_iov        = &empty_iov,
         .msg_iovlen     = 1,
         .msg_control    = &ctrl.data,
-        .msg_controllen = ctrl.data.cmsg_len,
+        .msg_controllen = sizeof(ctrl.buf),
         .msg_flags      = 0,
     };
 #ifdef MSG_CMSG_CLOEXEC
@@ -1926,9 +1943,16 @@ static int recvfd_lua(lua_State *L)
         return 2;
 
     default:
+        // the cmsg_len guard keeps the memcpy below from reading an
+        // uninitialized payload when the kernel delivers a malformed
+        // SCM_RIGHTS header
         if (ctrl.data.cmsg_level == SOL_SOCKET &&
-            ctrl.data.cmsg_type == SCM_RIGHTS) {
-            int fd = *(int *)CMSG_DATA(&ctrl.data);
+            ctrl.data.cmsg_type == SCM_RIGHTS &&
+            ctrl.data.cmsg_len >= CMSG_LEN(sizeof(int))) {
+            int fd = 0;
+            // CMSG_DATA() alignment is only guaranteed for the cmsghdr
+            // itself, so the payload is read byte-wise via memcpy
+            memcpy(&fd, CMSG_DATA(&ctrl.data), sizeof(fd));
 #ifndef MSG_CMSG_CLOEXEC
             // Portable fallback for platforms without MSG_CMSG_CLOEXEC
             // (macOS, BSD).  Not race-free with a concurrent exec, but
@@ -2442,7 +2466,7 @@ static int unwrap_lua(lua_State *L)
 
 static int wrap_lua(lua_State *L)
 {
-    int fd = (int)lauxh_checkinteger(L, 1);
+    lua_Integer fd = lauxh_checkinteger(L, 1);
     struct sockaddr_storage addr;
     socklen_t addrlen = sizeof(struct sockaddr_storage);
     net_socket_t *s   = NULL;
@@ -2451,13 +2475,22 @@ static int wrap_lua(lua_State *L)
     socklen_t protolen = sizeof(int);
 #endif
 
+    // narrowing an out-of-range lua_Integer to int would wrap onto an
+    // unrelated descriptor number; reject before touching any fd
+    if (fd < 0 || fd > INT_MAX) {
+        lua_pushnil(L);
+        errno = EINVAL;
+        lua_errno_new(L, errno, "wrap_lua");
+        return 2;
+    }
+
     lua_settop(L, 1);
 
     // allocate a new socket userdata and initialize it with the provided file
     // descriptor.
     s  = lua_newuserdata(L, sizeof(net_socket_t));
     *s = (net_socket_t){
-        .fd            = fd,
+        .fd            = (int)fd,
         .family        = 0,
         .socktype      = 0,
         .protocol      = 0,
@@ -2465,19 +2498,20 @@ static int wrap_lua(lua_State *L)
         .gc_thread     = lua_newthread(L),
     };
 
-    if (getsockname(fd, (void *)&addr, &addrlen) != 0) {
+    if (getsockname(s->fd, (void *)&addr, &addrlen) != 0) {
         lua_pushnil(L);
         lua_errno_new(L, errno, "getsockname");
         return 2;
     } else if (
 #if defined(SO_PROTOCOL)
-        getsockopt(fd, SOL_SOCKET, SO_PROTOCOL, &s->protocol, &protolen) != 0 ||
+        getsockopt(s->fd, SOL_SOCKET, SO_PROTOCOL, &s->protocol, &protolen) !=
+            0 ||
 #endif
-        getsockopt(fd, SOL_SOCKET, SO_TYPE, &s->socktype, &typelen) != 0) {
+        getsockopt(s->fd, SOL_SOCKET, SO_TYPE, &s->socktype, &typelen) != 0) {
         lua_pushnil(L);
         lua_errno_new(L, errno, "getsockopt");
         return 2;
-    } else if (set_cloexec_nonblock_nosigpipe(fd) == -1) {
+    } else if (set_cloexec_nonblock_nosigpipe(s->fd) == -1) {
         lua_pushnil(L);
         lua_errno_new(L, errno, "fcntl");
         return 2;
@@ -2496,17 +2530,35 @@ static int wrap_lua(lua_State *L)
 
 static int shutdownfd_lua(lua_State *L)
 {
-    int fd  = (int)lauxh_checkinteger(L, 1);
-    int how = checkshutflag(L, 2, SHUT_RDWR);
-    return shutdownfd(L, fd, how);
+    lua_Integer fd = lauxh_checkinteger(L, 1);
+    int how        = checkshutflag(L, 2, SHUT_RDWR);
+
+    // narrowing an out-of-range lua_Integer to int would shut down an
+    // unrelated descriptor; reject before touching any fd
+    if (fd < 0 || fd > INT_MAX) {
+        lua_pushboolean(L, 0);
+        errno = EINVAL;
+        lua_errno_new(L, errno, "shutdownfd_lua");
+        return 2;
+    }
+    return shutdownfd(L, (int)fd, how);
 }
 
 static int closefd_lua(lua_State *L)
 {
-    int fd            = (int)lauxh_checkinteger(L, 1);
+    lua_Integer fd    = lauxh_checkinteger(L, 1);
     int with_shutdown = !lua_isnoneornil(L, 2);
     int how           = checkshutflag(L, 2, -1);
-    return closefd(L, fd, how, with_shutdown);
+
+    // narrowing an out-of-range lua_Integer to int would close an
+    // unrelated descriptor; reject before touching any fd
+    if (fd < 0 || fd > INT_MAX) {
+        lua_pushboolean(L, 0);
+        errno = EINVAL;
+        lua_errno_new(L, errno, "closefd_lua");
+        return 2;
+    }
+    return closefd(L, (int)fd, how, with_shutdown);
 }
 
 // Parsed opts destination for net.socket.new / net.socket.pair.

--- a/src/tls_context.c
+++ b/src/tls_context.c
@@ -612,13 +612,25 @@ static inline size_t get_bio_bufcap(SSL *ssl, lua_Integer bufcap)
 static int accept_lua(lua_State *L)
 {
     tls_server_t *s    = luaL_checkudata(L, 1, NET_TLS_SERVER_MT);
-    int fd             = lauxh_checkinteger(L, 2);
+    lua_Integer fdarg  = lauxh_checkinteger(L, 2);
     int use_bio        = lauxh_optboolean(L, 3, 0);
     lua_Integer bufcap = lauxh_optinteger(L, 4, 0);
-    tls_ctx_t *ctx     = lua_newuserdata(L, sizeof(tls_ctx_t));
+    int fd             = 0;
+    tls_ctx_t *ctx     = NULL;
     const char *errop  = NULL;
     const char *errmsg = NULL;
 
+    // narrowing an out-of-range lua_Integer to int would hand OpenSSL an
+    // unrelated descriptor number; reject before any allocation
+    if (fdarg < 0 || fdarg > INT_MAX) {
+        lua_pushnil(L);
+        errno = EINVAL;
+        lua_errno_new(L, errno, "accept");
+        return 2;
+    }
+    fd = (int)fdarg;
+
+    ctx               = lua_newuserdata(L, sizeof(tls_ctx_t));
     ctx->handshake_cb = SSL_accept;
     ctx->parent       = s;
     ctx->ssl          = SSL_new(s->ctx);
@@ -676,7 +688,7 @@ static int noverify_time_cb(int preverify_ok, X509_STORE_CTX *x509_ctx)
 static int connect_lua(lua_State *L)
 {
     tls_client_t *c        = luaL_checkudata(L, 1, NET_TLS_CLIENT_MT);
-    int fd                 = lauxh_checkinteger(L, 2);
+    lua_Integer fdarg      = lauxh_checkinteger(L, 2);
     size_t len             = 0;
     const char *servername = luaL_optlstring(L, 3, NULL, &len);
     int noverify_name      = lauxh_optboolean(L, 4, 0);
@@ -684,7 +696,8 @@ static int connect_lua(lua_State *L)
     int noverify_cert      = lauxh_optboolean(L, 6, 0);
     int use_bio            = lauxh_optboolean(L, 7, 0);
     lua_Integer bufcap     = lauxh_optinteger(L, 8, 0);
-    tls_ctx_t *ctx         = lua_newuserdata(L, sizeof(tls_ctx_t));
+    int fd                 = 0;
+    tls_ctx_t *ctx         = NULL;
     union {
         struct in_addr ip4;
         struct in6_addr ip6;
@@ -698,6 +711,17 @@ static int connect_lua(lua_State *L)
     const char *errop  = NULL;
     const char *errmsg = NULL;
 
+    // narrowing an out-of-range lua_Integer to int would hand OpenSSL an
+    // unrelated descriptor number; reject before any allocation
+    if (fdarg < 0 || fdarg > INT_MAX) {
+        lua_pushnil(L);
+        errno = EINVAL;
+        lua_errno_new(L, errno, "connect");
+        return 2;
+    }
+    fd = (int)fdarg;
+
+    ctx               = lua_newuserdata(L, sizeof(tls_ctx_t));
     ctx->handshake_cb = SSL_connect;
     ctx->parent       = c;
     ctx->ssl          = SSL_new(c->ctx);

--- a/test/socket_test.lua
+++ b/test/socket_test.lua
@@ -3188,6 +3188,133 @@ function testcase.sendfd_on_closed_socket()
     assert(err)
 end
 
+function testcase.sendfd_rejects_out_of_range_fd()
+    -- Casting the lua_Integer fd straight to int wrapped out-of-range
+    -- values onto unrelated descriptor numbers in the SCM_RIGHTS payload.
+    -- Values outside 0..INT_MAX must be rejected with EINVAL instead.
+    local socks = assert(socket.pair({
+        socktype = 'stream',
+    }))
+    local a = socks[1]
+
+    local rv, err = a:sendfd(2147483648)
+    assert.is_nil(rv)
+    assert(err)
+    assert.equal(err.type, errno.EINVAL)
+
+    rv, err = a:sendfd(-1)
+    assert.is_nil(rv)
+    assert(err)
+    assert.equal(err.type, errno.EINVAL)
+
+    a:close()
+    socks[2]:close()
+end
+
+function testcase.wrap_rejects_out_of_range_fd()
+    -- wrap() used to cast the lua_Integer argument straight to int, so an
+    -- out-of-range value could wrap onto an unrelated fd number.
+    local rv, err = socket.wrap(2147483648)
+    assert.is_nil(rv)
+    assert(err)
+    assert.equal(err.type, errno.EINVAL)
+
+    rv, err = socket.wrap(-1)
+    assert.is_nil(rv)
+    assert(err)
+    assert.equal(err.type, errno.EINVAL)
+end
+
+function testcase.shutdown_close_reject_out_of_range_fd()
+    -- shutdown()/close() on an out-of-range fd used to truncate the value
+    -- to int and could hit an unrelated descriptor; both must fail with
+    -- EINVAL before touching any fd.
+    local ok, err = socket.shutdown(2147483648)
+    assert.is_false(ok)
+    assert(err)
+    assert.equal(err.type, errno.EINVAL)
+
+    ok, err = socket.close(2147483648)
+    assert.is_false(ok)
+    assert(err)
+    assert.equal(err.type, errno.EINVAL)
+
+    ok, err = socket.close(-1)
+    assert.is_false(ok)
+    assert(err)
+    assert.equal(err.type, errno.EINVAL)
+end
+
+function testcase.sendfile_rejects_out_of_range_fd()
+    -- Integer fd arguments beyond the int range must fail with EINVAL
+    -- before the platform-specific sendfile branch truncates them.
+    local socks = assert(socket.pair({
+        socktype = 'stream',
+    }))
+    local a = socks[1]
+
+    local rv, err = a:sendfile(2147483648, 8, 0)
+    assert.is_nil(rv)
+    assert(err)
+    assert.equal(err.type, errno.EINVAL)
+
+    rv, err = a:sendfile(-1, 8, 0)
+    assert.is_nil(rv)
+    assert(err)
+    assert.equal(err.type, errno.EINVAL)
+
+    a:close()
+    socks[2]:close()
+end
+
+function testcase.sendmsg_cmsg_rejects_out_of_range_fd()
+    -- cmsg SCM_RIGHTS data must be an integral fd within 0..INT_MAX; the
+    -- old code accepted any number and truncated it when casting to int.
+    local socks = assert(socket.pair({
+        socktype = 'stream',
+    }))
+    local a = socks[1]
+
+    local err = assert.throws(function()
+        a:sendmsg('x', nil, {
+            {
+                level = 'socket',
+                type = 'rights',
+                data = 2147483648,
+            },
+        })
+    end)
+    assert.match(err, 'fd', false)
+
+    err = assert.throws(function()
+        a:sendmsg('x', nil, {
+            {
+                level = 'socket',
+                type = 'rights',
+                data = 1.5,
+            },
+        })
+    end)
+    assert.match(err, 'fd', false)
+
+    err = assert.throws(function()
+        a:sendmsg('x', nil, {
+            {
+                level = 'socket',
+                type = 'rights',
+                data = {
+                    0,
+                    2147483648,
+                },
+            },
+        })
+    end)
+    assert.match(err, 'fd', false)
+
+    a:close()
+    socks[2]:close()
+end
+
 function testcase.recvfd()
     -- Basic reception via SCM_RIGHTS: sendfd on one end, recvfd on the other.
     local socks = assert(socket.pair({
@@ -5998,7 +6125,8 @@ function testcase.addgcfn_too_many_arguments()
     -- registering until the guard fires instead of assuming a threshold.
     local fired = false
     for _ = 1, 1000000 do
-        local ok = pcall(s.addgcfn, s, nil, function() end, unpack(args))
+        local ok = pcall(s.addgcfn, s, nil, function()
+        end, unpack(args))
         if not ok then
             fired = true
             break
@@ -6022,7 +6150,8 @@ function testcase.addgcfn_repeated_registration_hits_guard()
     local ok = true
     local err
     for _ = 1, 10000 do
-        ok, err = pcall(s.addgcfn, s, nil, function() end)
+        ok, err = pcall(s.addgcfn, s, nil, function()
+        end)
         if not ok then
             break
         end

--- a/test/tls/context_test.lua
+++ b/test/tls/context_test.lua
@@ -495,6 +495,39 @@ function testcase.encrypted_length()
     assert.equal(tls_context.encrypted_length('tlsv1.3'), 16645)
 end
 
+function testcase.accept_rejects_out_of_range_fd()
+    -- accept() used to cast the lua_Integer fd straight to int, so an
+    -- out-of-range value could wrap onto an unrelated fd number and be
+    -- handed to OpenSSL.  It must fail with EINVAL instead.
+    local server = assert(new_tls_server(SERVER_CONFIG.cert, SERVER_CONFIG.key))
+
+    local ctx, err = tls_context.accept(server, 2147483648)
+    assert.is_nil(ctx)
+    assert(err)
+    assert.equal(err.type, errno.EINVAL)
+
+    ctx, err = tls_context.accept(server, -1)
+    assert.is_nil(ctx)
+    assert(err)
+    assert.equal(err.type, errno.EINVAL)
+end
+
+function testcase.connect_rejects_out_of_range_fd()
+    -- connect() has the same lua_Integer-to-int truncation hazard as
+    -- accept(); out-of-range fds must fail with EINVAL.
+    local client = assert(new_tls_client())
+
+    local ctx, err = tls_context.connect(client, 2147483648)
+    assert.is_nil(ctx)
+    assert(err)
+    assert.equal(err.type, errno.EINVAL)
+
+    ctx, err = tls_context.connect(client, -1)
+    assert.is_nil(ctx)
+    assert(err)
+    assert.equal(err.type, errno.EINVAL)
+end
+
 -- WANT_READ / WANT_WRITE indicate a retryable SSL condition
 local WANT = {
     [tls_context.WANT_READ] = true,
@@ -1289,9 +1322,11 @@ function testcase.connect_accepts_ip_servername_with_verify()
                                               false, false, false, false)
         assert(ctx, cerr and tostring(cerr) or
                    'connect must accept IP servername with verify enabled')
-        for _, s in ipairs(socks) do
-            s:close()
-        end
+    end
+    -- close only after the loop: connect() now rejects the -1 fd reported by
+    -- a closed socket instead of silently handing it to OpenSSL.
+    for _, s in ipairs(socks) do
+        s:close()
     end
 end
 


### PR DESCRIPTION
Every fd-accepting entry point cast its lua_Integer argument
straight to int, so values outside 0..INT_MAX silently wrapped
onto a different, possibly open descriptor: sendfd() queued an
unrelated fd in its SCM_RIGHTS payload, and shutdown()/close()/
wrap()/tls accept/connect handed the wrapped number to syscalls
or OpenSSL.  All of them now fail with EINVAL before touching
any fd; fd liveness stays with the kernel's EBADF.

The cmsg table data used by sendmsg() additionally requires an
integral value, since Lua 5.1/5.2 silently truncate 1.5 to 1.
sendfd()/recvfd() also stop casting CMSG_DATA() to int * in favor
of memcpy, set msg_controllen to the full control buffer size, and
recvfd() refuses to read a malformed SCM_RIGHTS cmsg whose
cmsg_len cannot hold an int.